### PR TITLE
Fix typo in Makefile for Bootstrap provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -387,7 +387,7 @@ manifest-modification: # Set the manifest images to the staging/production bucke
 release-manifests: $(RELEASE_DIR) $(KUSTOMIZE) ## Build the manifests to publish with a release
 	# Build bootstrap-components.
 	$(KUSTOMIZE) build bootstrap/config/default > $(RELEASE_DIR)/bootstrap-components.yaml
-	$(MAKE) set-manifest-image MANIFEST_IMG=$(CONTROLPLANE_IMG) MANIFEST_TAG=$(TAG) TARGET_RESOURCE="$(RELEASE_DIR)/bootstrap-components.yaml"
+	$(MAKE) set-manifest-image MANIFEST_IMG=$(BOOTSTRAP_IMG) MANIFEST_TAG=$(TAG) TARGET_RESOURCE="$(RELEASE_DIR)/bootstrap-components.yaml"
 	# Build control-plane-components.
 	$(KUSTOMIZE) build controlplane/config/default > $(RELEASE_DIR)/control-plane-components.yaml
 	$(MAKE) set-manifest-image MANIFEST_IMG=$(CONTROLPLANE_IMG) MANIFEST_TAG=$(TAG) TARGET_RESOURCE="$(RELEASE_DIR)/control-plane-components.yaml"
@@ -426,7 +426,7 @@ docker-push-manifest-rke2-bootstrap: ## Push the multiarch manifest for the rke2
 	docker manifest create --amend $(BOOTSTRAP_IMG):$(TAG) $(shell echo $(ALL_ARCH) | sed -e "s~[^ ]*~$(BOOTSTRAP_IMG)\-&:$(TAG)~g")
 	@for arch in $(ALL_ARCH); do docker manifest annotate --arch $${arch} ${BOOTSTRAP_IMG}:${TAG} ${BOOTSTRAP_IMG}-$${arch}:${TAG}; done
 	docker manifest push --purge $(BOOTSTRAP_IMG):$(TAG)
-	$(MAKE) set-manifest-image MANIFEST_IMG=$(BOOTSTRAP_IMG) MANIFEST_TAG=$(TAG) TARGET_RESOURCE="./bootstrap/config/default/manager_image_patch.yaml"
+	## $(MAKE) set-manifest-image MANIFEST_IMG=$(BOOTSTRAP_IMG) MANIFEST_TAG=$(TAG) TARGET_RESOURCE="./bootstrap/config/default/manager_image_patch.yaml"
 	$(MAKE) set-manifest-pull-policy TARGET_RESOURCE="./bootstrap/config/default/manager_pull_policy.yaml"
 
 .PHONY: docker-push-manifest-rke2-control-plane

--- a/samples/aws/external/cluster-template-external-cloud-provider.yaml
+++ b/samples/aws/external/cluster-template-external-cloud-provider.yaml
@@ -755,7 +755,7 @@ data:
               env:
                 - name: ADDRESS
                   value: /var/lib/csi/sockets/pluginproxy/csi.sock
-              image: registry.k8.io/sig-storage/csi-provisioner:v2.1.1
+              image: registry.k8s.io/sig-storage/csi-provisioner:v2.1.1
               name: csi-provisioner
               volumeMounts:
                 - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -767,7 +767,7 @@ data:
               env:
                 - name: ADDRESS
                   value: /var/lib/csi/sockets/pluginproxy/csi.sock
-              image: registry.k8.io/sig-storage/csi-attacher:v3.1.0
+              image: registry.k8s.io/sig-storage/csi-attacher:v3.1.0
               name: csi-attacher
               volumeMounts:
                 - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -778,7 +778,7 @@ data:
               env:
                 - name: ADDRESS
                   value: /var/lib/csi/sockets/pluginproxy/csi.sock
-              image: registry.k8.io/sig-storage/csi-snapshotter:v3.0.3
+              image: registry.k8s.io/sig-storage/csi-snapshotter:v3.0.3
               name: csi-snapshotter
               volumeMounts:
                 - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -789,7 +789,7 @@ data:
               env:
                 - name: ADDRESS
                   value: /var/lib/csi/sockets/pluginproxy/csi.sock
-              image: registry.k8.io/sig-storage/csi-resizer:v1.0.0
+              image: registry.k8s.io/sig-storage/csi-resizer:v1.0.0
               imagePullPolicy: Always
               name: csi-resizer
               volumeMounts:
@@ -797,7 +797,7 @@ data:
                   name: socket-dir
             - args:
                 - --csi-address=/csi/csi.sock
-              image: registry.k8.io/sig-storage/livenessprobe:v2.2.0
+              image: registry.k8s.io/sig-storage/livenessprobe:v2.2.0
               name: liveness-probe
               volumeMounts:
                 - mountPath: /csi


### PR DESCRIPTION
Small fix to the AWS manifests to make the cloud controller deploy correctly

<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
This PR fixes an issue with release manifest generation and AWS sample deployment manifests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
