### PR TITLE
Updated VMware example files due to updates to the RKE2 Provider

### DIFF
--- a/samples/vmware/README.md
+++ b/samples/vmware/README.md
@@ -1,4 +1,6 @@
-# VMWare Example Manifests
+# Example manifests
+
+This config includes a kubevip loadbalancer on the controlplane nodes. The VIP of the loadbalancer for the Kubernetes API is set by the CABPR_CONTROLPLANE_ENDPOINT variable.
 
 Usage: 
 
@@ -11,6 +13,7 @@ export CABPR_CP_REPLICAS=3
 export CABPR_WK_REPLICAS=2
 export KUBERNETES_VERSION=v1.24.6
 export RKE2_VERSION=v1.24.6+rke2r1
+export CABPR_CONTROLPLANE_ENDPOINT=192.168.1.100
 
 export CABPR_VCENTER_HOSTNAME=vcenter.example.com
 export CABPR_VCENTER_USERNAME=admin
@@ -27,7 +30,10 @@ export CABPR_VCENTER_VM_MEMORY=4096
 export CABPR_VCENTER_VM_TEMPLATE=template
 ```
 
+Create the namespace first.
+
 run:
 ```shell
+envsubt < namespace.yaml | kubectl apply -f -
 envsubt < *.yaml | kubectl apply -f -
 ```

--- a/samples/vmware/cluster.yaml
+++ b/samples/vmware/cluster.yaml
@@ -1,8 +1,9 @@
+---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster 
 metadata:
   namespace: ${CABPR_NAMESPACE}
-  name: vsphere-test 
+  name: ${CABPR_CLUSTER_NAME}
   labels:
     cluster.x-k8s.io/cluster-name: ${CABPR_CLUSTER_NAME}
 spec:
@@ -18,4 +19,5 @@ spec:
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: VSphereCluster
-    name: vsphere-test
+    name: ${CABPR_CLUSTER_NAME}
+

--- a/samples/vmware/machinedeployment.yaml
+++ b/samples/vmware/machinedeployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
@@ -28,3 +29,5 @@ spec:
         kind: VSphereMachineTemplate
         name: vsphere-worker
         namespace: ${CABPR_NAMESPACE}
+
+

--- a/samples/vmware/namespace.yaml
+++ b/samples/vmware/namespace.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/samples/vmware/rke2configtemplate.yaml
+++ b/samples/vmware/rke2configtemplate.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
 kind: RKE2ConfigTemplate
 metadata:
@@ -6,6 +7,8 @@ metadata:
 spec: 
   template:
     spec:
+      preRKE2Commands:
+        - sleep 30 # fix to give OS time to become ready
       agentConfig:
         version: ${RKE2_VERSION}
         kubelet:

--- a/samples/vmware/rke2controlplane.yaml
+++ b/samples/vmware/rke2controlplane.yaml
@@ -1,16 +1,129 @@
-apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha1 
 kind: RKE2ControlPlane
 metadata:
   name: rke2-control-plane
   namespace: ${CABPR_NAMESPACE}
 spec: 
+  files:
+    - path: "/var/lib/rancher/rke2/server/manifests/coredns-config.yaml"
+      owner: "root:root"
+      permissions: "0640"
+      content: |
+        apiVersion: helm.cattle.io/v1
+        kind: HelmChartConfig
+        metadata:
+          name: rke2-coredns
+          namespace: kube-system
+        spec:
+          valuesContent: |-
+            tolerations:
+              - key: "node.cloudprovider.kubernetes.io/uninitialized"
+                value: "true"
+                effect: "NoSchedule"
+    - path: "/var/lib/rancher/rke2/server/manifests/kubevip.yaml"
+      owner: "root:root"
+      permissions: "0640"
+      content: |
+        apiVersion: v1
+        kind: ServiceAccount
+        metadata:
+          name: kube-vip
+          namespace: kube-system
+        ---
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        metadata:
+          annotations:
+            rbac.authorization.kubernetes.io/autoupdate: "true"
+          name: system:kube-vip-role
+        rules:
+          - apiGroups: [""]
+            resources: ["services", "services/status", "nodes"]
+            verbs: ["list","get","watch", "update"]
+          - apiGroups: ["coordination.k8s.io"]
+            resources: ["leases"]
+            verbs: ["list", "get", "watch", "update", "create"]
+        ---
+        kind: ClusterRoleBinding
+        apiVersion: rbac.authorization.k8s.io/v1
+        metadata:
+          name: system:kube-vip-binding
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: system:kube-vip-role
+        subjects:
+        - kind: ServiceAccount
+          name: kube-vip
+          namespace: kube-system
+        ---
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          creationTimestamp: null
+          name: kube-vip
+          namespace: kube-system
+        spec:
+          tolerations:
+          - effect: NoSchedule
+            key: node.cloudprovider.kubernetes.io/uninitialized
+            operator: Exists
+          containers:
+          - args:
+            - manager
+            env:
+            - name: cp_enable
+              value: "true"
+            - name: vip_interface
+              value: eth0
+            - name: address
+              value: ${CABPR_CONTROLPLANE_ENDPOINT}
+            - name: port
+              value: "6443"
+            - name: vip_arp
+              value: "true"
+            - name: vip_leaderelection
+              value: "true"
+            - name: vip_leaseduration
+              value: "15"
+            - name: vip_renewdeadline
+              value: "10"
+            - name: vip_retryperiod
+              value: "2"
+            image: ghcr.io/kube-vip/kube-vip:v0.5.5
+            imagePullPolicy: IfNotPresent
+            name: kube-vip
+            resources: {}
+            securityContext:
+              capabilities:
+                add:
+                - NET_ADMIN
+                - NET_RAW
+            volumeMounts:
+            - mountPath: /etc/rancher/rke2/rke2.yaml
+              name: kubeconfig
+          hostAliases:
+          - hostnames:
+            - kubernetes
+            ip: 127.0.0.1
+          hostNetwork: true
+          serviceAccountName: kube-vip
+          volumes:
+          - hostPath:
+              path: /etc/rancher/rke2/rke2.yaml
+              type: File
+            name: kubeconfig
   replicas: ${CABPR_CP_REPLICAS}
-  version: ${RKE2_VERSION}
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: VSphereMachineTemplate
     name: vsphere-controlplane
   nodeDrainTimeout: 2m
-  kubelet:
-    extraArgs:
-      - "--cloud-provider=external"
+  preRKE2Commands:
+    - sleep 30 #fix to give OS time to become ready
+  agentConfig:    
+    version: ${RKE2_VERSION}
+    kubelet:
+      extraArgs:
+        - "--cloud-provider=external"

--- a/samples/vmware/vmware-cpi-with-csi.yaml
+++ b/samples/vmware/vmware-cpi-with-csi.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
 metadata:

--- a/samples/vmware/vspherecluster.yaml
+++ b/samples/vmware/vspherecluster.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereCluster
 metadata:
@@ -5,7 +6,7 @@ metadata:
   namespace: ${CABPR_NAMESPACE}
 spec:
   controlPlaneEndpoint:
-    host: ${CABPR_VCENTER_NAME}
+    host: ${CABPR_CONTROLPLANE_ENDPOINT}
     port: 6443
   identityRef:
     kind: Secret

--- a/samples/vmware/vspheremachinetemplate.yaml
+++ b/samples/vmware/vspheremachinetemplate.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereMachineTemplate
 metadata:
@@ -9,7 +10,7 @@ spec:
       cloneMode: linkedClone
       datacenter: ${CABPR_VCENTER_DATACENTER}
       datastore: ${CABPR_VCENTER_DATASTORE}
-      diskGiB:
+      diskGiB: ${CABPR_VCENTER_DISKSIZE}
       folder: ${CABPR_VCENTER_FOLDER}
       memoryMiB: ${CABPR_VCENTER_VM_MEMORY}
       network:
@@ -18,7 +19,7 @@ spec:
           networkName: ${CABPR_VCENTER_NETWORK}
       numCPUs: ${CABPR_VCENTER_VM_VPCU}
       os: Linux
-      resourcePool: ${CABPR_VCENTER_RESOURCEPOOL}
+      resourcePool: "${CABPR_VCENTER_RESOURCEPOOL}"
       server: ${CABPR_VCENTER_HOSTNAME}
       storagePolicyName: ""
       template: ${CABPR_VCENTER_VM_TEMPLATE}
@@ -44,7 +45,7 @@ spec:
           networkName: ${CABPR_VCENTER_NETWORK}
       numCPUs: ${CABPR_VCENTER_VM_VPCU}
       os: Linux
-      resourcePool: ${CABPR_VCENTER_RESOURCEPOOL}
+      resourcePool: "${CABPR_VCENTER_RESOURCEPOOL}"
       server: ${CABPR_VCENTER_HOSTNAME}
       storagePolicyName: ""
       template: ${CABPR_VCENTER_VM_TEMPLATE}


### PR DESCRIPTION
**What this PR does / why we need it**:
Updated VMware example files due to updates to the RKE2 Provider

This config uses the external VMware Cloud Provider (kublet arg `cloud-provider=external`), due to this the taint `node.cloudprovider.kubernetes.io/uninitialized` is set. Because of this taint the coredns pods wont start, so no DNS. Therfor the cloud provider cannot reach the vCenter server and set the providerId on the node. Without providerId the node isn't marked ready. By adding a toleration to the coredns pods this is solved. The toleration is set in the RKE2ControlPlane spec with a HelmChartConfig file.

More information: [https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/](https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/)

The VMware Cloud Provider needs an external IP for to connect to the API, kubevip provides this and is configured via a manifest. (See RKE2ControlPlane spec).

Also made some changes due to changes in the RKE2 Provider.

**Checklist**:
- [X] squashed commits into logical changes
- [X] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
