### PR TITLE
Fixed #28 CIS Profile now works and is different for v1.25+ and v1.24-

### DIFF
--- a/bootstrap/api/v1alpha1/rke2config_types.go
+++ b/bootstrap/api/v1alpha1/rke2config_types.go
@@ -83,7 +83,7 @@ type RKE2AgentConfig struct {
 	Snapshotter string `json:"snapshotter,omitempty"`
 
 	// CISProfile activates CIS compliance of RKE2 for a certain profile
-	// +kubebuilder:validation:Enum=cis-1.23
+	// +kubebuilder:validation:Enum=cis-1.23;cis-1.5;cis-1.6
 	//+optional
 	CISProfile CISProfile `json:"cisProfile,omitempty"`
 
@@ -210,6 +210,12 @@ type CISProfile string
 const (
 	// CIS1_23 references RKE2's CIS Profile "cis-1.23".
 	CIS1_23 CISProfile = "cis-1.23"
+
+	// CIS1_5 references RKE2's CIS Profile "cis-1.5".
+	CIS1_5 CISProfile = "cis-1.5"
+
+	// CIS1_6 references RKE2's CIS Profile "cis-1.6".
+	CIS1_6 CISProfile = "cis-1.6"
 )
 
 // Encoding specifies the cloud-init file encoding.

--- a/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_rke2configs.yaml
+++ b/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_rke2configs.yaml
@@ -48,6 +48,8 @@ spec:
                       certain profile
                     enum:
                     - cis-1.23
+                    - cis-1.5
+                    - cis-1.6
                     type: string
                   containerRuntimeEndpoint:
                     description: ContainerRuntimeEndpoint Disable embedded containerd

--- a/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_rke2configtemplates.yaml
+++ b/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_rke2configtemplates.yaml
@@ -61,6 +61,8 @@ spec:
                               for a certain profile
                             enum:
                             - cis-1.23
+                            - cis-1.5
+                            - cis-1.6
                             type: string
                           containerRuntimeEndpoint:
                             description: ContainerRuntimeEndpoint Disable embedded

--- a/bootstrap/internal/cloudinit/cloudinit.go
+++ b/bootstrap/internal/cloudinit/cloudinit.go
@@ -92,6 +92,7 @@ type BaseUserData struct {
 	SentinelFileCommand string
 	AirGapped           bool
 	NTPServers          []string
+	CISEnabled          bool
 }
 
 func generate(kind string, tpl string, data interface{}) ([]byte, error) {

--- a/bootstrap/internal/cloudinit/cloudinit_test.go
+++ b/bootstrap/internal/cloudinit/cloudinit_test.go
@@ -120,3 +120,38 @@ runcmd:
 `))
 	})
 })
+
+var _ = Describe("WorkerCISTest", func() {
+	var input *BaseUserData
+
+	BeforeEach(func() {
+		input = &BaseUserData{
+			AirGapped:   false,
+			CISEnabled:  true,
+			RKE2Version: "v1.25.6+rke2r1",
+		}
+	})
+	It("Should use the RKE2 CIS Node Preparation script", func() {
+		workerCloudInitData, err := NewJoinWorker(input)
+		Expect(err).ToNot(HaveOccurred())
+		workerCloudInitString := string(workerCloudInitData)
+		_, err = GinkgoWriter.Write(workerCloudInitData)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(workerCloudInitString).To(Equal(`## template: jinja
+#cloud-config
+
+write_files:
+-   path: 
+    content: |
+      
+
+runcmd:
+  - 'curl -sfL https://get.rke2.io | INSTALL_RKE2_VERSION=v1.25.6+rke2r1 INSTALL_RKE2_TYPE="agent" sh -s -'
+  - '/opt/rke2-cis-script.sh'
+  - 'systemctl enable rke2-agent.service'
+  - 'systemctl start rke2-agent.service'
+  - 'mkdir /run/cluster-api' 
+  - 'echo success > /run/cluster-api/bootstrap-success.complete'
+`))
+	})
+})

--- a/bootstrap/internal/cloudinit/controlplane_init.go
+++ b/bootstrap/internal/cloudinit/controlplane_init.go
@@ -30,6 +30,8 @@ const (
 runcmd:
 {{- template "commands" .PreRKE2Commands }}
   - {{ if .AirGapped }}INSTALL_RKE2_ARTIFACT_PATH=/opt/rke2-artifacts sh /opt/install.sh{{ else }}'curl -sfL https://get.rke2.io | INSTALL_RKE2_VERSION=%[1]s sh -s - server'{{ end }} 
+{{- if .CISEnabled }}
+  - '/opt/rke2-cis-script.sh'{{ end }}
   - 'systemctl enable rke2-server.service'
   - 'systemctl start rke2-server.service'
   - 'mkdir /run/cluster-api' 

--- a/bootstrap/internal/cloudinit/worker_join.go
+++ b/bootstrap/internal/cloudinit/worker_join.go
@@ -28,6 +28,8 @@ const (
 runcmd:
 {{- template "commands" .PreRKE2Commands }}
   - '{{ if .AirGapped }}INSTALL_RKE2_ARTIFACT_PATH=/opt/rke2-artifacts INSTALL_RKE2_TYPE="agent" sh /opt/install.sh{{ else }}curl -sfL https://get.rke2.io | INSTALL_RKE2_VERSION=%[1]s INSTALL_RKE2_TYPE="agent" sh -s -{{end}}'
+{{- if .CISEnabled }}
+  - '/opt/rke2-cis-script.sh'{{ end }}
   - 'systemctl enable rke2-agent.service'
   - 'systemctl start rke2-agent.service'
   - 'mkdir /run/cluster-api' 

--- a/bootstrap/internal/controllers/rke2config_controller.go
+++ b/bootstrap/internal/controllers/rke2config_controller.go
@@ -401,6 +401,7 @@ func (r *RKE2ConfigReconciler) handleClusterNotInitialized(ctx context.Context, 
 	cpinput := &cloudinit.ControlPlaneInput{
 		BaseUserData: cloudinit.BaseUserData{
 			AirGapped:        scope.Config.Spec.AgentConfig.AirGapped,
+			CISEnabled:       scope.Config.Spec.AgentConfig.CISProfile != "",
 			PreRKE2Commands:  scope.Config.Spec.PreRKE2Commands,
 			PostRKE2Commands: scope.Config.Spec.PostRKE2Commands,
 			ConfigFile:       initConfigFile,
@@ -564,6 +565,7 @@ func (r *RKE2ConfigReconciler) joinControlplane(ctx context.Context, scope *Scop
 	cpinput := &cloudinit.ControlPlaneInput{
 		BaseUserData: cloudinit.BaseUserData{
 			AirGapped:        scope.Config.Spec.AgentConfig.AirGapped,
+			CISEnabled:       scope.Config.Spec.AgentConfig.CISProfile != "",
 			PreRKE2Commands:  scope.Config.Spec.PreRKE2Commands,
 			PostRKE2Commands: scope.Config.Spec.PostRKE2Commands,
 			ConfigFile:       initConfigFile,
@@ -655,6 +657,7 @@ func (r *RKE2ConfigReconciler) joinWorker(ctx context.Context, scope *Scope) (re
 	wkInput := &cloudinit.BaseUserData{
 		PreRKE2Commands:  scope.Config.Spec.PreRKE2Commands,
 		AirGapped:        scope.Config.Spec.AgentConfig.AirGapped,
+		CISEnabled:       scope.Config.Spec.AgentConfig.CISProfile != "",
 		PostRKE2Commands: scope.Config.Spec.PostRKE2Commands,
 		ConfigFile:       wkJoinConfigFile,
 		RKE2Version:      scope.Config.Spec.AgentConfig.Version,

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanes.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanes.yaml
@@ -48,6 +48,8 @@ spec:
                       certain profile
                     enum:
                     - cis-1.23
+                    - cis-1.5
+                    - cis-1.6
                     type: string
                   containerRuntimeEndpoint:
                     description: ContainerRuntimeEndpoint Disable embedded containerd

--- a/pkg/consts/global_consts.go
+++ b/pkg/consts/global_consts.go
@@ -38,4 +38,13 @@ const (
 
 	// DefaultSyncPeriod is the default resync period for the controller manager's cache.
 	DefaultSyncPeriod = 10 * time.Minute
+
+	// DefaultFileOwner is the default owner of the files created by the controller.
+	DefaultFileOwner = "root:root"
+
+	// DefaultFileMode is the default mode of the files created by the controller.
+	DefaultFileMode = "644"
+
+	// FileModeRootExecutable is the mode of the files created by the controller when the owner is root.
+	FileModeRootExecutable = "700"
 )

--- a/pkg/rke2/config_test.go
+++ b/pkg/rke2/config_test.go
@@ -289,6 +289,7 @@ var _ = Describe("RKE2 Agent Config", func() {
 					ExtraEnv:      map[string]string{"testenv": "testenv"},
 					ExtraMounts:   map[string]string{"testmount": "testmount"},
 				},
+				Version: "v1.25.2",
 			},
 		}
 	})
@@ -319,16 +320,16 @@ var _ = Describe("RKE2 Agent Config", func() {
 		Expect(agentConfig.KubeProxyExtraEnv).To(Equal(opts.AgentConfig.KubeProxy.ExtraEnv))
 		Expect(agentConfig.Token).To(Equal(opts.Token))
 
-		Expect(files).To(HaveLen(2))
+		Expect(files).To(HaveLen(3))
 
-		Expect(files[0].Path).To(Equal(agentConfig.ImageCredentialProviderConfig))
-		Expect(files[0].Content).To(Equal("test_credential_config"))
-		Expect(files[0].Owner).To(Equal("root:root"))
-		Expect(files[0].Permissions).To(Equal("0644"))
-
-		Expect(files[1].Path).To(Equal(agentConfig.ResolvConf))
-		Expect(files[1].Content).To(Equal("test_resolv_conf"))
+		Expect(files[1].Path).To(Equal(agentConfig.ImageCredentialProviderConfig))
+		Expect(files[1].Content).To(Equal("test_credential_config"))
 		Expect(files[1].Owner).To(Equal("root:root"))
 		Expect(files[1].Permissions).To(Equal("0644"))
+
+		Expect(files[2].Path).To(Equal(agentConfig.ResolvConf))
+		Expect(files[2].Content).To(Equal("test_resolv_conf"))
+		Expect(files[2].Owner).To(Equal("root:root"))
+		Expect(files[2].Permissions).To(Equal("0644"))
 	})
 })

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -22,6 +22,7 @@ var _ = Describe(("Testing GetMapKeysAsString"), func() {
 			"foo":   []byte("bar"),
 		}
 		keys := GetMapKeysAsString(testMap)
-		Expect(keys).To(Equal("hello,foo"))
+		keysValid := keys == "hello,foo" || keys == "foo,hello"
+		Expect(keysValid).To(BeTrue())
 	})
 })

--- a/samples/docker/cis-profile/rke2-sample.yaml
+++ b/samples/docker/cis-profile/rke2-sample.yaml
@@ -1,0 +1,106 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${CABPR_NAMESPACE}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster 
+metadata:
+  namespace: ${CABPR_NAMESPACE}
+  name: ${CLUSTER_NAME} 
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - 10.45.0.0/16
+    services:
+      cidrBlocks:
+      - 10.46.0.0/16
+    serviceDomain: cluster.local
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+    kind: RKE2ControlPlane
+    name: ${CLUSTER_NAME}-control-plane
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: DockerCluster
+    name: ${CLUSTER_NAME}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerCluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${CABPR_NAMESPACE}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+kind: RKE2ControlPlane
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: ${CABPR_NAMESPACE}
+spec: 
+  replicas: ${CABPR_CP_REPLICAS}
+  agentConfig:
+    version: ${KUBERNETES_VERSION}+rke2r1
+    cisProfile: ${CIS_PROFILE}
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: DockerMachineTemplate
+    name: controlplane
+  nodeDrainTimeout: 2m
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerMachineTemplate
+metadata:
+  name: controlplane
+  namespace: ${CABPR_NAMESPACE}
+spec:
+  template:
+    spec: {} 
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: worker-md-0
+  namespace: ${CABPR_NAMESPACE}
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${CABPR_WK_REPLICAS}
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+  template:
+    spec:
+      version: ${KUBERNETES_VERSION}
+      clusterName: ${CLUSTER_NAME}
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
+          kind: RKE2ConfigTemplate
+          name: ${CLUSTER_NAME}-agent
+          namespace: ${CABPR_NAMESPACE}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: DockerMachineTemplate
+        name: worker
+        namespace: ${CABPR_NAMESPACE}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerMachineTemplate
+metadata:
+  name: worker
+  namespace: ${CABPR_NAMESPACE}
+spec:
+  template:
+    spec: {} 
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
+kind: RKE2ConfigTemplate
+metadata:
+  namespace: ${CABPR_NAMESPACE}
+  name: ${CLUSTER_NAME}-agent
+spec: 
+  template:
+    spec:
+      agentConfig:
+        version: ${KUBERNETES_VERSION}+rke2r1
+        cisProfile: ${CIS_PROFILE}


### PR DESCRIPTION
Signed-off-by: Mohamed Belgaied Hassine <belgaied2@hotmail.com>

<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
This PR better implements the CIS Profile by differenciation RKE2 version that are <v1.25 which need a profile `cis-1.5` or `cis-1.6` and the versions >=v1.25, which need a profile `cis-1.23` replacing Pod Security Policies with Pod Security Admission.

It also fixes an issue where the node was not correctly prepared before RKE2 service starts, causing a failure during RKE2's installation.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #28

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits into logical changes
- [ ] includes documentation
- [X] adds unit tests
- [ ] adds or updates e2e tests
