### PR TITLE
moved useful constants to own package

### DIFF
--- a/bootstrap/internal/controllers/rke2config_controller.go
+++ b/bootstrap/internal/controllers/rke2config_controller.go
@@ -44,6 +44,7 @@ import (
 	bootstrapv1 "github.com/rancher-sandbox/cluster-api-provider-rke2/bootstrap/api/v1alpha1"
 	"github.com/rancher-sandbox/cluster-api-provider-rke2/bootstrap/internal/cloudinit"
 	controlplanev1 "github.com/rancher-sandbox/cluster-api-provider-rke2/controlplane/api/v1alpha1"
+	"github.com/rancher-sandbox/cluster-api-provider-rke2/pkg/consts"
 	"github.com/rancher-sandbox/cluster-api-provider-rke2/pkg/locking"
 	"github.com/rancher-sandbox/cluster-api-provider-rke2/pkg/rke2"
 	"github.com/rancher-sandbox/cluster-api-provider-rke2/pkg/secret"
@@ -51,7 +52,6 @@ import (
 )
 
 const (
-	fileOwner        string = "root:root"
 	filePermissions  string = "0640"
 	registrationPort int    = 9345
 	serverURLFormat  string = "https://%v:%v"
@@ -366,7 +366,7 @@ func (r *RKE2ConfigReconciler) handleClusterNotInitialized(ctx context.Context, 
 	initConfigFile := bootstrapv1.File{
 		Path:        rke2.DefaultRKE2ConfigLocation,
 		Content:     string(b),
-		Owner:       fileOwner,
+		Owner:       consts.DefaultFileOwner,
 		Permissions: filePermissions,
 	}
 
@@ -456,7 +456,7 @@ func (r *RKE2ConfigReconciler) generateFileListIncludingRegistries(
 	initRegistriesFile := bootstrapv1.File{
 		Path:        rke2.DefaultRKE2RegistriesLocation,
 		Content:     string(registriesYAML),
-		Owner:       fileOwner,
+		Owner:       consts.DefaultFileOwner,
 		Permissions: filePermissions,
 	}
 
@@ -530,7 +530,7 @@ func (r *RKE2ConfigReconciler) joinControlplane(ctx context.Context, scope *Scop
 	initConfigFile := bootstrapv1.File{
 		Path:        rke2.DefaultRKE2ConfigLocation,
 		Content:     string(b),
-		Owner:       fileOwner,
+		Owner:       consts.DefaultFileOwner,
 		Permissions: filePermissions,
 	}
 
@@ -640,7 +640,7 @@ func (r *RKE2ConfigReconciler) joinWorker(ctx context.Context, scope *Scope) (re
 	wkJoinConfigFile := bootstrapv1.File{
 		Path:        rke2.DefaultRKE2ConfigLocation,
 		Content:     string(b),
-		Owner:       fileOwner,
+		Owner:       consts.DefaultFileOwner,
 		Permissions: filePermissions,
 	}
 

--- a/pkg/consts/global_consts.go
+++ b/pkg/consts/global_consts.go
@@ -43,7 +43,7 @@ const (
 	DefaultFileOwner = "root:root"
 
 	// DefaultFileMode is the default mode of the files created by the controller.
-	DefaultFileMode = "644"
+	DefaultFileMode = "0644"
 
 	// FileModeRootExecutable is the mode of the files created by the controller when the owner is root.
 	FileModeRootExecutable = "700"

--- a/pkg/rke2/config.go
+++ b/pkg/rke2/config.go
@@ -177,8 +177,8 @@ func newRKE2ServerConfig(opts ServerConfigOpts) (*rke2ServerConfig, []bootstrapv
 		files = append(files, bootstrapv1.File{
 			Path:        rke2ServerConfig.AuditPolicyFile,
 			Content:     string(auditPolicy),
-			Owner:       "root:root",
-			Permissions: "0644",
+			Owner:       consts.DefaultFileOwner,
+			Permissions: consts.DefaultFileMode,
 		})
 	}
 
@@ -218,8 +218,8 @@ func newRKE2ServerConfig(opts ServerConfigOpts) (*rke2ServerConfig, []bootstrapv
 		files = append(files, bootstrapv1.File{
 			Path:        rke2ServerConfig.CloudProviderConfig,
 			Content:     cloudProviderConfig,
-			Owner:       "root:root",
-			Permissions: "0644",
+			Owner:       consts.DefaultFileOwner,
+			Permissions: consts.DefaultFileMode,
 		})
 	}
 
@@ -295,7 +295,7 @@ func newRKE2ServerConfig(opts ServerConfigOpts) (*rke2ServerConfig, []bootstrapv
 			files = append(files, bootstrapv1.File{
 				Path:        rke2ServerConfig.EtcdS3EndpointCA,
 				Content:     string(caCert),
-				Owner:       "root:root",
+				Owner:       consts.DefaultFileOwner,
 				Permissions: "0640",
 			})
 		}
@@ -435,8 +435,8 @@ func newRKE2AgentConfig(opts AgentConfigOpts) (*rke2AgentConfig, []bootstrapv1.F
 		files = append(files, bootstrapv1.File{
 			Path:        rke2AgentConfig.CloudProviderConfig,
 			Content:     cloudProviderConfig,
-			Owner:       "root:root",
-			Permissions: "0644",
+			Owner:       consts.DefaultFileOwner,
+			Permissions: consts.DefaultFileMode,
 		})
 	}
 
@@ -469,8 +469,8 @@ func newRKE2AgentConfig(opts AgentConfigOpts) (*rke2AgentConfig, []bootstrapv1.F
 		files = append(files, bootstrapv1.File{
 			Path:        rke2AgentConfig.ImageCredentialProviderConfig,
 			Content:     credentialConfig,
-			Owner:       "root:root",
-			Permissions: "0644",
+			Owner:       consts.DefaultFileOwner,
+			Permissions: consts.DefaultFileMode,
 		})
 	}
 
@@ -503,8 +503,8 @@ func newRKE2AgentConfig(opts AgentConfigOpts) (*rke2AgentConfig, []bootstrapv1.F
 		files = append(files, bootstrapv1.File{
 			Path:        rke2AgentConfig.ResolvConf,
 			Content:     resolvConf,
-			Owner:       "root:root",
-			Permissions: "0644",
+			Owner:       consts.DefaultFileOwner,
+			Permissions: consts.DefaultFileMode,
 		})
 	}
 

--- a/pkg/rke2/config_test.go
+++ b/pkg/rke2/config_test.go
@@ -29,6 +29,7 @@ import (
 
 	bootstrapv1 "github.com/rancher-sandbox/cluster-api-provider-rke2/bootstrap/api/v1alpha1"
 	controlplanev1 "github.com/rancher-sandbox/cluster-api-provider-rke2/controlplane/api/v1alpha1"
+	"github.com/rancher-sandbox/cluster-api-provider-rke2/pkg/consts"
 )
 
 var _ = Describe("RKE2ServerConfig", func() {
@@ -224,17 +225,17 @@ var _ = Describe("RKE2ServerConfig", func() {
 
 		Expect(files[0].Path).To(Equal(rke2ServerConfig.AuditPolicyFile))
 		Expect(files[0].Content).To(Equal("test_audit"))
-		Expect(files[0].Owner).To(Equal("root:root"))
-		Expect(files[0].Permissions).To(Equal("0644"))
+		Expect(files[0].Owner).To(Equal(consts.DefaultFileOwner))
+		Expect(files[0].Permissions).To(Equal(consts.DefaultFileMode))
 
 		Expect(files[1].Path).To(Equal(rke2ServerConfig.CloudProviderConfig))
 		Expect(files[1].Content).To(Equal("test_cloud_config"))
-		Expect(files[1].Owner).To(Equal("root:root"))
-		Expect(files[1].Permissions).To(Equal("0644"))
+		Expect(files[1].Owner).To(Equal(consts.DefaultFileOwner))
+		Expect(files[1].Permissions).To(Equal(consts.DefaultFileMode))
 
 		Expect(files[2].Path).To(Equal(rke2ServerConfig.EtcdS3EndpointCA))
 		Expect(files[2].Content).To(Equal("test_ca"))
-		Expect(files[2].Owner).To(Equal("root:root"))
+		Expect(files[2].Owner).To(Equal(consts.DefaultFileOwner))
 		Expect(files[2].Permissions).To(Equal("0640"))
 	})
 })
@@ -324,12 +325,12 @@ var _ = Describe("RKE2 Agent Config", func() {
 
 		Expect(files[1].Path).To(Equal(agentConfig.ImageCredentialProviderConfig))
 		Expect(files[1].Content).To(Equal("test_credential_config"))
-		Expect(files[1].Owner).To(Equal("root:root"))
-		Expect(files[1].Permissions).To(Equal("0644"))
+		Expect(files[1].Owner).To(Equal(consts.DefaultFileOwner))
+		Expect(files[1].Permissions).To(Equal(consts.DefaultFileMode))
 
 		Expect(files[2].Path).To(Equal(agentConfig.ResolvConf))
 		Expect(files[2].Content).To(Equal("test_resolv_conf"))
-		Expect(files[2].Owner).To(Equal("root:root"))
-		Expect(files[2].Permissions).To(Equal("0644"))
+		Expect(files[2].Owner).To(Equal(consts.DefaultFileOwner))
+		Expect(files[2].Permissions).To(Equal(consts.DefaultFileMode))
 	})
 })

--- a/pkg/secret/certificates.go
+++ b/pkg/secret/certificates.go
@@ -37,12 +37,10 @@ import (
 	"sigs.k8s.io/cluster-api/util/certs"
 
 	bootstrapv1 "github.com/rancher-sandbox/cluster-api-provider-rke2/bootstrap/api/v1alpha1"
+	"github.com/rancher-sandbox/cluster-api-provider-rke2/pkg/consts"
 )
 
 const (
-	// rootOwnerValue is the Certificate Root Owner for creating new Certificate Authority.
-	rootOwnerValue = "root:root"
-
 	// DefaultCertificatesDir is the default location (file path) where the provider will put the certificates, this location will then
 	// be automatically used by RKE2 to use the pre-defined certificates instead of generating them.
 	DefaultCertificatesDir = "/var/lib/rancher/rke2/server/tls"
@@ -266,7 +264,7 @@ func (c *Certificate) AsFiles() []bootstrapv1.File {
 	if len(c.KeyPair.Cert) > 0 {
 		out = append(out, bootstrapv1.File{
 			Path:        c.CertFile,
-			Owner:       rootOwnerValue,
+			Owner:       consts.DefaultFileOwner,
 			Permissions: "0640",
 			Content:     string(c.KeyPair.Cert),
 		})
@@ -275,7 +273,7 @@ func (c *Certificate) AsFiles() []bootstrapv1.File {
 	if len(c.KeyPair.Key) > 0 {
 		out = append(out, bootstrapv1.File{
 			Path:        c.KeyFile,
-			Owner:       rootOwnerValue,
+			Owner:       consts.DefaultFileOwner,
 			Permissions: "0600",
 			Content:     string(c.KeyPair.Key),
 		})


### PR DESCRIPTION
Signed-off-by: Mohamed Belgaied Hassine <belgaied2@hotmail.com>

<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
This PR moves some constants and hard-coded values into public constants, in order to have a single reference for their values.


<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #81


**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
