### PR TITLE
Fixed a mistake in the description of ExtraArgs field

### DIFF
--- a/bootstrap/api/v1alpha1/rke2config_types.go
+++ b/bootstrap/api/v1alpha1/rke2config_types.go
@@ -335,7 +335,7 @@ type ComponentConfig struct {
 	//+optional
 	ExtraEnv map[string]string `json:"extraEnv,omitempty"`
 
-	// ExtraArgs is a map of command line arguments to pass to a Kubernetes Component command.
+	// ExtraArgs is a list of command line arguments (format: flag=value) to pass to a Kubernetes Component command.
 	//+optional
 	ExtraArgs []string `json:"extraArgs,omitempty"`
 

--- a/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_rke2configs.yaml
+++ b/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_rke2configs.yaml
@@ -109,8 +109,8 @@ spec:
                     description: KubeProxyArgs Customized flag for kube-proxy process.
                     properties:
                       extraArgs:
-                        description: ExtraArgs is a map of command line arguments
-                          to pass to a Kubernetes Component command.
+                        description: 'ExtraArgs is a list of command line arguments
+                          (format: flag=value) to pass to a Kubernetes Component command.'
                         items:
                           type: string
                         type: array
@@ -135,8 +135,8 @@ spec:
                     description: KubeletArgs Customized flag for kubelet process.
                     properties:
                       extraArgs:
-                        description: ExtraArgs is a map of command line arguments
-                          to pass to a Kubernetes Component command.
+                        description: 'ExtraArgs is a list of command line arguments
+                          (format: flag=value) to pass to a Kubernetes Component command.'
                         items:
                           type: string
                         type: array

--- a/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_rke2configtemplates.yaml
+++ b/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_rke2configtemplates.yaml
@@ -127,8 +127,9 @@ spec:
                               process.
                             properties:
                               extraArgs:
-                                description: ExtraArgs is a map of command line arguments
-                                  to pass to a Kubernetes Component command.
+                                description: 'ExtraArgs is a list of command line
+                                  arguments (format: flag=value) to pass to a Kubernetes
+                                  Component command.'
                                 items:
                                   type: string
                                 type: array
@@ -154,8 +155,9 @@ spec:
                             description: KubeletArgs Customized flag for kubelet process.
                             properties:
                               extraArgs:
-                                description: ExtraArgs is a map of command line arguments
-                                  to pass to a Kubernetes Component command.
+                                description: 'ExtraArgs is a list of command line
+                                  arguments (format: flag=value) to pass to a Kubernetes
+                                  Component command.'
                                 items:
                                   type: string
                                 type: array

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanes.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanes.yaml
@@ -109,8 +109,8 @@ spec:
                     description: KubeProxyArgs Customized flag for kube-proxy process.
                     properties:
                       extraArgs:
-                        description: ExtraArgs is a map of command line arguments
-                          to pass to a Kubernetes Component command.
+                        description: 'ExtraArgs is a list of command line arguments
+                          (format: flag=value) to pass to a Kubernetes Component command.'
                         items:
                           type: string
                         type: array
@@ -135,8 +135,8 @@ spec:
                     description: KubeletArgs Customized flag for kubelet process.
                     properties:
                       extraArgs:
-                        description: ExtraArgs is a map of command line arguments
-                          to pass to a Kubernetes Component command.
+                        description: 'ExtraArgs is a list of command line arguments
+                          (format: flag=value) to pass to a Kubernetes Component command.'
                         items:
                           type: string
                         type: array
@@ -601,8 +601,8 @@ spec:
                       of the Cloud Controller Manager.
                     properties:
                       extraArgs:
-                        description: ExtraArgs is a map of command line arguments
-                          to pass to a Kubernetes Component command.
+                        description: 'ExtraArgs is a list of command line arguments
+                          (format: flag=value) to pass to a Kubernetes Component command.'
                         items:
                           type: string
                         type: array
@@ -871,8 +871,9 @@ spec:
                           ETCD.
                         properties:
                           extraArgs:
-                            description: ExtraArgs is a map of command line arguments
-                              to pass to a Kubernetes Component command.
+                            description: 'ExtraArgs is a list of command line arguments
+                              (format: flag=value) to pass to a Kubernetes Component
+                              command.'
                             items:
                               type: string
                             type: array
@@ -905,8 +906,8 @@ spec:
                       of the Kube API Server.
                     properties:
                       extraArgs:
-                        description: ExtraArgs is a map of command line arguments
-                          to pass to a Kubernetes Component command.
+                        description: 'ExtraArgs is a list of command line arguments
+                          (format: flag=value) to pass to a Kubernetes Component command.'
                         items:
                           type: string
                         type: array
@@ -932,8 +933,8 @@ spec:
                       of the Kube Controller Manager.
                     properties:
                       extraArgs:
-                        description: ExtraArgs is a map of command line arguments
-                          to pass to a Kubernetes Component command.
+                        description: 'ExtraArgs is a list of command line arguments
+                          (format: flag=value) to pass to a Kubernetes Component command.'
                         items:
                           type: string
                         type: array
@@ -959,8 +960,8 @@ spec:
                       of the Kube Scheduler.
                     properties:
                       extraArgs:
-                        description: ExtraArgs is a map of command line arguments
-                          to pass to a Kubernetes Component command.
+                        description: 'ExtraArgs is a list of command line arguments
+                          (format: flag=value) to pass to a Kubernetes Component command.'
                         items:
                           type: string
                         type: array


### PR DESCRIPTION
Signed-off-by: Mohamed Belgaied Hassine <belgaied2@hotmail.com>

<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
The comment on the ExtraArgs field in ComponentConfig struct in the Bootstrap API suggests that the field should be a map whereas the field is actually a slice of strings with the format `flag=value`. This PR fixes this comment which appears as a field description when using `kubectl explain`.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #112

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
