### PR TITLE
Support ignition format for generating user data

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ run:
   skip-files:
     - "zz_generated.*\\.go$"
     - "vendored_openapi\\.go$"
+    - ".*_test\\.go$"
   allow-parallel-runners: true
 issues:
   include:

--- a/bootstrap/internal/controllers/rke2config_controller.go
+++ b/bootstrap/internal/controllers/rke2config_controller.go
@@ -414,23 +414,23 @@ func (r *RKE2ConfigReconciler) handleClusterNotInitialized(ctx context.Context, 
 		Certificates: certificates,
 	}
 
-	var cloudInitData []byte
+	var userData []byte
 
 	switch scope.Config.Spec.AgentConfig.Format {
 	case bootstrapv1.Ignition:
-		cloudInitData, err = ignition.NewInitControlPlane(&ignition.ControlPlaneInitInput{
+		userData, err = ignition.NewInitControlPlane(&ignition.ControlPlaneInput{
 			ControlPlaneInput:  cpinput,
 			AdditionalIgnition: &scope.Config.Spec.AgentConfig.AdditionalUserData,
 		})
 	default:
-		cloudInitData, err = cloudinit.NewInitControlPlane(cpinput)
+		userData, err = cloudinit.NewInitControlPlane(cpinput)
 	}
 
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	if err := r.storeBootstrapData(ctx, scope, cloudInitData); err != nil {
+	if err := r.storeBootstrapData(ctx, scope, userData); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -593,23 +593,23 @@ func (r *RKE2ConfigReconciler) joinControlplane(ctx context.Context, scope *Scop
 		return ctrl.Result{}, err
 	}
 
-	var cloudInitData []byte
+	var userData []byte
 
 	switch scope.Config.Spec.AgentConfig.Format {
 	case bootstrapv1.Ignition:
-		cloudInitData, err = ignition.NewJoinControlPlane(&ignition.ControlPlaneJoinInput{
+		userData, err = ignition.NewJoinControlPlane(&ignition.ControlPlaneInput{
 			ControlPlaneInput:  cpinput,
 			AdditionalIgnition: &scope.Config.Spec.AgentConfig.AdditionalUserData,
 		})
 	default:
-		cloudInitData, err = cloudinit.NewJoinControlPlane(cpinput)
+		userData, err = cloudinit.NewJoinControlPlane(cpinput)
 	}
 
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	if err := r.storeBootstrapData(ctx, scope, cloudInitData); err != nil {
+	if err := r.storeBootstrapData(ctx, scope, userData); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -695,23 +695,23 @@ func (r *RKE2ConfigReconciler) joinWorker(ctx context.Context, scope *Scope) (re
 		AdditionalCloudInit: scope.Config.Spec.AgentConfig.AdditionalUserData.Config,
 	}
 
-	var cloudInitData []byte
+	var userData []byte
 
 	switch scope.Config.Spec.AgentConfig.Format {
 	case bootstrapv1.Ignition:
-		cloudInitData, err = ignition.NewJoinWorker(&ignition.JoinWorkerInput{
+		userData, err = ignition.NewJoinWorker(&ignition.JoinWorkerInput{
 			BaseUserData:       wkInput,
 			AdditionalIgnition: &scope.Config.Spec.AgentConfig.AdditionalUserData,
 		})
 	default:
-		cloudInitData, err = cloudinit.NewJoinWorker(wkInput)
+		userData, err = cloudinit.NewJoinWorker(wkInput)
 	}
 
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	if err := r.storeBootstrapData(ctx, scope, cloudInitData); err != nil {
+	if err := r.storeBootstrapData(ctx, scope, userData); err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/bootstrap/internal/ignition/clc/clc.go
+++ b/bootstrap/internal/ignition/clc/clc.go
@@ -1,0 +1,268 @@
+/*
+Copyright 2023 SUSE.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clc
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"text/template"
+
+	clct "github.com/flatcar/container-linux-config-transpiler/config"
+	ignition "github.com/flatcar/ignition/config/v2_3"
+	ignitionTypes "github.com/flatcar/ignition/config/v2_3/types"
+	"github.com/pkg/errors"
+
+	bootstrapv1 "github.com/rancher-sandbox/cluster-api-provider-rke2/bootstrap/api/v1alpha1"
+	"github.com/rancher-sandbox/cluster-api-provider-rke2/bootstrap/internal/cloudinit"
+)
+
+// The template contains configurations for two main sections: systemd units and storage files.
+// The first section defines two systemd units: rke2-install.service and ntpd.service.
+// The rke2-install.service unit is enabled and is executed only once during the boot process to run the /etc/rke2-install.sh script.
+// This script installs and deploys RKE2, and performs pre and post-installation commands.
+// The ntpd.service unit is enabled only if NTP servers are specified.
+// The second section defines storage files for the system. It creates a file at /etc/rke2-install.sh. If CISEnabled is set to true,
+// it runs an additional CIS script to enforce system security standards. If NTP servers are specified,
+// it creates an NTP configuration file at /etc/ntp.conf.
+const (
+	clcTemplate = `---
+systemd:
+  units:
+    - name: rke2-install.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=rke2-install
+        [Service]
+        # To not restart the unit when it exits, as it is expected.
+        Type=oneshot
+        ExecStart=/etc/rke2-install.sh
+        [Install]
+        WantedBy=multi-user.target
+    {{- if .NTPServers }}
+    - name: ntpd.service
+      enabled: true
+    {{- end }}
+storage:
+  files:
+    - path: /etc/ssh/sshd_config
+      mode: 0600
+      contents:
+        inline: |
+          # Use most defaults for sshd configuration.
+          Subsystem sftp internal-sftp
+          ClientAliveInterval 180
+          UseDNS no
+          UsePAM yes
+          PrintLastLog no # handled by PAM
+          PrintMotd no # handled by PAM
+    {{- range .WriteFiles }}
+    - path: {{ .Path }}
+      {{- $owner := ParseOwner .Owner }}
+      {{ if $owner.User -}}
+      user:
+        name: {{ $owner.User }}
+      {{- end }}
+      {{ if $owner.Group -}}
+      group:
+        name: {{ $owner.Group }}
+      {{- end }}
+      # Owner
+      {{ if ne .Permissions "" -}}
+      mode: {{ .Permissions }}
+      {{ end -}}
+      contents:
+        {{ if eq .Encoding "base64" -}}
+        inline: !!binary |
+        {{- else -}}
+        inline: |
+        {{- end }}
+          {{ .Content | Indent 10 }}
+    {{- end }}
+    - path: /etc/rke2-install.sh
+      mode: 0700
+      contents:
+        inline: |
+          #!/bin/bash
+          set -e
+          {{ range .PreRKE2Commands }}
+          {{ . | Indent 10 }}
+          {{- end }}
+
+		  {{- if .CISEnabled }}
+  		  /opt/rke2-cis-script.sh
+		  {{ end }}
+
+          {{ range .DeployRKE2Commands }}
+          {{ . | Indent 10 }}
+          {{- end }}
+
+          mkdir -p /run/cluster-api && echo success > /run/cluster-api/bootstrap-success.complete
+          {{range .PostRKE2Commands }}
+          {{ . | Indent 10 }}
+          {{- end }}
+    {{- if .NTPServers }}
+    - path: /etc/ntp.conf
+      mode: 0644
+      contents:
+        inline: |
+          # Common pool
+          {{- range  .NTPServers }}
+          server {{ . }}
+          {{- end }}
+
+          # Warning: Using default NTP settings will leave your NTP
+          # server accessible to all hosts on the Internet.
+
+          # If you want to deny all machines (including your own)
+          # from accessing the NTP server, uncomment:
+          #restrict default ignore
+
+          # Default configuration:
+          # - Allow only time queries, at a limited rate, sending KoD when in excess.
+          # - Allow all local queries (IPv4, IPv6)
+          restrict default nomodify nopeer noquery notrap limited kod
+          restrict 127.0.0.1
+          restrict [::1]
+    {{- end }}
+`
+)
+
+func defaultTemplateFuncMap() template.FuncMap {
+	return template.FuncMap{
+		"Indent":     templateYAMLIndent,
+		"ParseOwner": parseOwner,
+	}
+}
+
+func templateYAMLIndent(i int, input string) string {
+	split := strings.Split(input, "\n")
+	ident := "\n" + strings.Repeat(" ", i)
+
+	return strings.Join(split, ident)
+}
+
+type owner struct {
+	User  *string
+	Group *string
+}
+
+func parseOwner(ownerRaw string) owner {
+	if ownerRaw == "" {
+		return owner{}
+	}
+
+	ownerSlice := strings.Split(ownerRaw, ":")
+
+	parseEntity := func(entity string) *string {
+		if entity == "" {
+			return nil
+		}
+
+		entityTrimmed := strings.TrimSpace(entity)
+
+		return &entityTrimmed
+	}
+
+	if len(ownerSlice) == 1 {
+		return owner{
+			User: parseEntity(ownerSlice[0]),
+		}
+	}
+
+	return owner{
+		User:  parseEntity(ownerSlice[0]),
+		Group: parseEntity(ownerSlice[1]),
+	}
+}
+
+func renderCLC(input *cloudinit.BaseUserData) ([]byte, error) {
+	t := template.Must(template.New("template").Funcs(defaultTemplateFuncMap()).Parse(clcTemplate))
+
+	var out bytes.Buffer
+	if err := t.Execute(&out, input); err != nil {
+		return nil, errors.Wrapf(err, "failed to render template")
+	}
+
+	return out.Bytes(), nil
+}
+
+// Render renders the provided user data and CLC snippets into Ignition config.
+func Render(input *cloudinit.BaseUserData, additionalConfig *bootstrapv1.AdditionalUserData) ([]byte, error) {
+	if input == nil {
+		return nil, errors.New("empty base user data")
+	}
+
+	clcBytes, err := renderCLC(input)
+	if err != nil {
+		return nil, errors.Wrapf(err, "rendering CLC configuration")
+	}
+
+	userData, _, err := buildIgnitionConfig(clcBytes, additionalConfig)
+	if err != nil {
+		return nil, errors.Wrapf(err, "building Ignition config")
+	}
+
+	return userData, nil
+}
+
+func buildIgnitionConfig(baseCLC []byte, additionalConfig *bootstrapv1.AdditionalUserData) ([]byte, string, error) {
+	// We control baseCLC config, so treat it as strict.
+	ign, _, err := clcToIgnition(baseCLC, true)
+	if err != nil {
+		return nil, "", errors.Wrapf(err, "converting generated CLC to Ignition")
+	}
+
+	var clcWarnings string
+
+	if additionalConfig != nil && additionalConfig.Config != "" {
+		additionalIgn, warnings, err := clcToIgnition([]byte(additionalConfig.Config), additionalConfig.Strict)
+		if err != nil {
+			return nil, "", errors.Wrapf(err, "converting additional CLC to Ignition")
+		}
+
+		clcWarnings = warnings
+
+		ign = ignition.Append(ign, additionalIgn)
+	}
+
+	userData, err := json.Marshal(&ign)
+	if err != nil {
+		return nil, "", errors.Wrapf(err, "marshaling generated Ignition config into JSON")
+	}
+
+	return userData, clcWarnings, nil
+}
+
+func clcToIgnition(data []byte, strict bool) (ignitionTypes.Config, string, error) {
+	clc, ast, reports := clct.Parse(data)
+
+	if (len(reports.Entries) > 0 && strict) || reports.IsFatal() {
+		return ignitionTypes.Config{}, "", fmt.Errorf("error parsing Container Linux Config: %v", reports.String())
+	}
+
+	ign, report := clct.Convert(clc, "", ast)
+	if (len(report.Entries) > 0 && strict) || report.IsFatal() {
+		return ignitionTypes.Config{}, "", fmt.Errorf("error converting to Ignition: %v", report.String())
+	}
+
+	reports.Merge(report)
+
+	return ign, reports.String(), nil
+}

--- a/bootstrap/internal/ignition/clc/clc_test.go
+++ b/bootstrap/internal/ignition/clc/clc_test.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2023 SUSE.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clc
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	ignition "github.com/flatcar/ignition/config/v2_3"
+	"k8s.io/utils/pointer"
+
+	bootstrapv1 "github.com/rancher-sandbox/cluster-api-provider-rke2/bootstrap/api/v1alpha1"
+	"github.com/rancher-sandbox/cluster-api-provider-rke2/bootstrap/internal/cloudinit"
+)
+
+func TestCLC(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CLC Suite")
+}
+
+var additionalIgnition = `---
+systemd:
+  units:
+    - name: test.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=test
+        [Service]
+        ExecStart=/etc/test.sh
+        [Install]
+        WantedBy=test.target
+`
+
+var _ = Describe("Render", func() {
+	var (
+		input            *cloudinit.BaseUserData
+		additionalConfig *bootstrapv1.AdditionalUserData
+	)
+
+	BeforeEach(func() {
+		input = &cloudinit.BaseUserData{
+			PreRKE2Commands: []string{
+				"echo 'test'",
+			},
+			PostRKE2Commands: []string{
+				"echo 'test'",
+			},
+			NTPServers: []string{
+				"test",
+			},
+			RKE2Version: "v1.21.3+rke2r1",
+			WriteFiles: []bootstrapv1.File{
+				{
+					Path:        "/test/file",
+					Content:     "test",
+					Permissions: "0644",
+				},
+				{
+					Path:        "/test/base64",
+					Encoding:    bootstrapv1.Base64,
+					Content:     "Zm9vCg==",
+					Permissions: "0644",
+				},
+			},
+			ConfigFile: bootstrapv1.File{
+				Path:        "/test/config",
+				Content:     "test",
+				Permissions: "0644",
+			},
+		}
+
+		additionalConfig = &bootstrapv1.AdditionalUserData{
+			Config: additionalIgnition,
+			Strict: true,
+		}
+	})
+
+	It("should render a valid ignition config", func() {
+		ignitionJson, err := Render(input, additionalConfig)
+		Expect(err).ToNot(HaveOccurred())
+
+		ign, reports, err := ignition.Parse(ignitionJson)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(reports.IsFatal()).To(BeFalse())
+
+		Expect(ign.Ignition.Version).To(Equal("2.3.0"))
+
+		Expect(ign.Storage.Files).To(HaveLen(5))
+
+		Expect(ign.Storage.Files[0].Filesystem).To(Equal("root"))
+		Expect(ign.Storage.Files[0].Path).To(Equal("/etc/ssh/sshd_config"))
+
+		Expect(ign.Storage.Files[1].Filesystem).To(Equal("root"))
+		Expect(ign.Storage.Files[1].Path).To(Equal("/test/file"))
+
+		Expect(ign.Storage.Files[2].Filesystem).To(Equal("root"))
+		Expect(ign.Storage.Files[2].Path).To(Equal("/test/base64"))
+
+		Expect(ign.Storage.Files[3].Filesystem).To(Equal("root"))
+		Expect(ign.Storage.Files[3].Path).To(Equal("/etc/rke2-install.sh"))
+
+		Expect(ign.Storage.Files[4].Filesystem).To(Equal("root"))
+		Expect(ign.Storage.Files[4].Path).To(Equal("/etc/ntp.conf"))
+
+		Expect(ign.Systemd.Units).To(HaveLen(3))
+		Expect(ign.Systemd.Units[0].Name).To(Equal("rke2-install.service"))
+		Expect(ign.Systemd.Units[0].Contents).To(Equal("[Unit]\nDescription=rke2-install\n[Service]\n# To not restart the unit when it exits, as it is expected.\nType=oneshot\nExecStart=/etc/rke2-install.sh\n[Install]\nWantedBy=multi-user.target\n"))
+		Expect(ign.Systemd.Units[0].Enabled).To(Equal(pointer.Bool(true)))
+
+		Expect(ign.Systemd.Units[1].Name).To(Equal("ntpd.service"))
+		Expect(ign.Systemd.Units[1].Enabled).To(Equal(pointer.Bool(true)))
+
+		Expect(ign.Systemd.Units[2].Name).To(Equal("test.service"))
+		Expect(ign.Systemd.Units[2].Contents).To(Equal("[Unit]\nDescription=test\n[Service]\nExecStart=/etc/test.sh\n[Install]\nWantedBy=test.target\n"))
+		Expect(ign.Systemd.Units[2].Enabled).To(Equal(pointer.Bool(true)))
+	})
+
+	It("accepts empty additional config", func() {
+		additionalConfig = nil
+		_, err := Render(input, additionalConfig)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should return error if input is nil", func() {
+		_, err := Render(nil, additionalConfig)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("treats warnings as errors in strict mode", func() {
+		// Should generate an Ignition warning about the colon in the partition label.
+		configWithIgnitionWarning := `---
+storage:
+  disks:
+  - device: /dev/sda
+    partitions:
+    - label: foo:bar
+`
+
+		additionalConfig = &bootstrapv1.AdditionalUserData{
+			Config: configWithIgnitionWarning,
+			Strict: true,
+		}
+
+		_, err := Render(input, additionalConfig)
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/bootstrap/internal/ignition/ignition.go
+++ b/bootstrap/internal/ignition/ignition.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2023 SUSE.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package ignition aggregates all Ignition flavors into a single package to be consumed
+// by the bootstrap provider by exposing an API similar to 'internal/cloudinit' package.
+package ignition
+
+import (
+	"fmt"
+
+	bootstrapv1 "github.com/rancher-sandbox/cluster-api-provider-rke2/bootstrap/api/v1alpha1"
+	"github.com/rancher-sandbox/cluster-api-provider-rke2/bootstrap/internal/cloudinit"
+	"github.com/rancher-sandbox/cluster-api-provider-rke2/bootstrap/internal/ignition/clc"
+)
+
+const (
+	airGappedControlPlaneCommand = "INSTALL_RKE2_ARTIFACT_PATH=/opt/rke2-artifacts sh /opt/install.sh"
+	controlPlaneCommand          = "curl -sfL https://get.rke2.io | INSTALL_RKE2_VERSION=%[1]s sh -s - server"
+	airGappedWorkerCommand       = "INSTALL_RKE2_ARTIFACT_PATH=/opt/rke2-artifacts INSTALL_RKE2_TYPE=\"agent\" sh /opt/install.sh"
+	workerCommand                = "curl -sfL https://get.rke2.io | INSTALL_RKE2_VERSION=%[1]s INSTALL_RKE2_TYPE=\"agent\" sh -s -"
+)
+
+var (
+	serverSystemdServices = []string{
+		"systemctl enable rke2-server.service",
+		"systemctl start rke2-server.service",
+	}
+
+	workerSystemdServices = []string{
+		"systemctl enable rke2-agent.service",
+		"systemctl start rke2-agent.service",
+	}
+)
+
+// JoinWorkerInput defines the context to generate a node user data.
+type JoinWorkerInput struct {
+	*cloudinit.BaseUserData
+
+	AdditionalIgnition *bootstrapv1.AdditionalUserData
+}
+
+// ControlPlaneJoinInput defines context to generate controlplane instance user data for control plane node join.
+type ControlPlaneJoinInput struct {
+	*cloudinit.ControlPlaneInput
+
+	AdditionalIgnition *bootstrapv1.AdditionalUserData
+}
+
+// ControlPlaneInitInput defines the context to generate a controlplane instance user data.
+type ControlPlaneInitInput struct {
+	*cloudinit.ControlPlaneInput
+
+	AdditionalIgnition *bootstrapv1.AdditionalUserData
+}
+
+// NewJoinWorker returns Ignition configuration for new worker node joining the cluster.
+func NewJoinWorker(input *JoinWorkerInput) ([]byte, error) {
+	if input == nil {
+		return nil, fmt.Errorf("input can't be nil")
+	}
+
+	if input.BaseUserData == nil {
+		return nil, fmt.Errorf("node input can't be nil")
+	}
+
+	deployRKE2Command, err := getWorkerRKE2Commands(input.BaseUserData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get rke2 command: %w", err)
+	}
+
+	input.DeployRKE2Commands = deployRKE2Command
+	input.WriteFiles = append(input.WriteFiles, input.ConfigFile)
+
+	return render(input.BaseUserData, input.AdditionalIgnition)
+}
+
+// NewJoinControlPlane returns Ignition configuration for new controlplane node joining the cluster.
+func NewJoinControlPlane(input *ControlPlaneJoinInput) ([]byte, error) {
+	if input == nil {
+		return nil, fmt.Errorf("input can't be nil")
+	}
+
+	if input.ControlPlaneInput == nil {
+		return nil, fmt.Errorf("controlplane join input can't be nil")
+	}
+
+	deployRKE2Command, err := getControlPlaneRKE2Commands(&input.BaseUserData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get rke2 command: %w", err)
+	}
+
+	input.DeployRKE2Commands = deployRKE2Command
+	input.WriteFiles = append(input.WriteFiles, input.Certificates.AsFiles()...)
+	input.WriteFiles = append(input.WriteFiles, input.ConfigFile)
+
+	return render(&input.BaseUserData, input.AdditionalIgnition)
+}
+
+// NewInitControlPlane returns Ignition configuration for bootstrapping new cluster.
+func NewInitControlPlane(input *ControlPlaneInitInput) ([]byte, error) {
+	if input == nil {
+		return nil, fmt.Errorf("input can't be nil")
+	}
+
+	if input.ControlPlaneInput == nil {
+		return nil, fmt.Errorf("controlplane input can't be nil")
+	}
+
+	deployRKE2Command, err := getControlPlaneRKE2Commands(&input.BaseUserData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get rke2 command: %w", err)
+	}
+
+	input.DeployRKE2Commands = deployRKE2Command
+	input.WriteFiles = append(input.WriteFiles, input.Certificates.AsFiles()...)
+	input.WriteFiles = append(input.WriteFiles, input.ConfigFile)
+
+	return render(&input.BaseUserData, input.AdditionalIgnition)
+}
+
+func render(input *cloudinit.BaseUserData, ignitionConfig *bootstrapv1.AdditionalUserData) ([]byte, error) {
+	additionalCLCConfig := &bootstrapv1.AdditionalUserData{}
+	if ignitionConfig != nil && ignitionConfig.Config != "" {
+		additionalCLCConfig = ignitionConfig
+	}
+
+	return clc.Render(input, additionalCLCConfig)
+}
+
+func getControlPlaneRKE2Commands(baseUserData *cloudinit.BaseUserData) ([]string, error) {
+	if baseUserData == nil {
+		return nil, fmt.Errorf("base user data can't be nil")
+	}
+
+	if baseUserData.RKE2Version == "" {
+		return nil, fmt.Errorf("rke2 version can't be empty")
+	}
+
+	rke2Commands := []string{}
+
+	if baseUserData.AirGapped {
+		rke2Commands = append(rke2Commands, airGappedControlPlaneCommand)
+	} else {
+		rke2Commands = append(rke2Commands, fmt.Sprintf(controlPlaneCommand, baseUserData.RKE2Version))
+	}
+
+	rke2Commands = append(rke2Commands, serverSystemdServices...)
+
+	return rke2Commands, nil
+}
+
+func getWorkerRKE2Commands(baseUserData *cloudinit.BaseUserData) ([]string, error) {
+	if baseUserData == nil {
+		return nil, fmt.Errorf("base user data can't be nil")
+	}
+
+	if baseUserData.RKE2Version == "" {
+		return nil, fmt.Errorf("rke2 version can't be empty")
+	}
+
+	rke2Commands := []string{}
+
+	if baseUserData.AirGapped {
+		rke2Commands = append(rke2Commands, airGappedWorkerCommand)
+	} else {
+		rke2Commands = append(rke2Commands, fmt.Sprintf(workerCommand, baseUserData.RKE2Version))
+	}
+
+	rke2Commands = append(rke2Commands, workerSystemdServices...)
+
+	return rke2Commands, nil
+}

--- a/bootstrap/internal/ignition/ignition_test.go
+++ b/bootstrap/internal/ignition/ignition_test.go
@@ -95,10 +95,10 @@ var _ = Describe("NewJoinWorker", func() {
 })
 
 var _ = Describe("NewJoinControlPlane", func() {
-	var input *ControlPlaneJoinInput
+	var input *ControlPlaneInput
 
 	BeforeEach(func() {
-		input = &ControlPlaneJoinInput{
+		input = &ControlPlaneInput{
 			ControlPlaneInput: &cloudinit.ControlPlaneInput{
 				BaseUserData: cloudinit.BaseUserData{
 					RKE2Version: "v1.21.3+rke2r1",
@@ -123,7 +123,7 @@ var _ = Describe("NewJoinControlPlane", func() {
 		}
 	})
 
-	It("should return ignition data for worker", func() {
+	It("should return ignition data for control plane", func() {
 		ignition, err := NewJoinControlPlane(input)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ignition).ToNot(BeNil())
@@ -145,10 +145,10 @@ var _ = Describe("NewJoinControlPlane", func() {
 })
 
 var _ = Describe("NewInitControlPlane", func() {
-	var input *ControlPlaneInitInput
+	var input *ControlPlaneInput
 
 	BeforeEach(func() {
-		input = &ControlPlaneInitInput{
+		input = &ControlPlaneInput{
 			ControlPlaneInput: &cloudinit.ControlPlaneInput{
 				BaseUserData: cloudinit.BaseUserData{
 					RKE2Version: "v1.21.3+rke2r1",
@@ -173,7 +173,7 @@ var _ = Describe("NewInitControlPlane", func() {
 		}
 	})
 
-	It("should return ignition data for worker", func() {
+	It("should return ignition data for control plane", func() {
 		ignition, err := NewInitControlPlane(input)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ignition).ToNot(BeNil())
@@ -203,14 +203,14 @@ var _ = Describe("getControlPlaneRKE2Commands", func() {
 		}
 	})
 
-	It("should return slice of commands", func() {
+	It("should return slice of control plane commands", func() {
 		commands, err := getControlPlaneRKE2Commands(baseUserData)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(commands).To(HaveLen(3))
 		Expect(commands).To(ContainElements(fmt.Sprintf(controlPlaneCommand, baseUserData.RKE2Version), serverSystemdServices[0], serverSystemdServices[1]))
 	})
 
-	It("should return slice of commands with air gapped", func() {
+	It("should return slice of control plane commands with air gapped", func() {
 		baseUserData.AirGapped = true
 		commands, err := getControlPlaneRKE2Commands(baseUserData)
 		Expect(err).ToNot(HaveOccurred())
@@ -243,14 +243,14 @@ var _ = Describe("getWorkerRKE2Commands", func() {
 		}
 	})
 
-	It("should return slice of commands", func() {
+	It("should return slice of worker commands", func() {
 		commands, err := getWorkerRKE2Commands(baseUserData)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(commands).To(HaveLen(3))
 		Expect(commands).To(ContainElements(fmt.Sprintf(workerCommand, baseUserData.RKE2Version), workerSystemdServices[0], workerSystemdServices[1]))
 	})
 
-	It("should return slice of commands with air gapped", func() {
+	It("should return slice of worker commands with air gapped", func() {
 		baseUserData.AirGapped = true
 		commands, err := getWorkerRKE2Commands(baseUserData)
 		Expect(err).ToNot(HaveOccurred())

--- a/bootstrap/internal/ignition/ignition_test.go
+++ b/bootstrap/internal/ignition/ignition_test.go
@@ -1,0 +1,274 @@
+/*
+Copyright 2023 SUSE.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ignition
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	bootstrapv1 "github.com/rancher-sandbox/cluster-api-provider-rke2/bootstrap/api/v1alpha1"
+	"github.com/rancher-sandbox/cluster-api-provider-rke2/bootstrap/internal/cloudinit"
+)
+
+func TestIgnition(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Ignition Suite")
+}
+
+var additionalIgnition = `---
+systemd:
+  units:
+    - name: test.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=test
+        [Service]
+        ExecStart=/etc/test.sh
+        [Install]
+        WantedBy=test.target
+`
+
+var _ = Describe("NewJoinWorker", func() {
+	var input *JoinWorkerInput
+
+	BeforeEach(func() {
+		input = &JoinWorkerInput{
+			BaseUserData: &cloudinit.BaseUserData{
+				RKE2Version: "v1.21.3+rke2r1",
+				WriteFiles: []bootstrapv1.File{
+					{
+						Path:        "/test/file",
+						Content:     "test",
+						Permissions: "0644",
+					},
+				},
+				ConfigFile: bootstrapv1.File{
+					Path:        "/test/config",
+					Content:     "test",
+					Permissions: "0644",
+				},
+			},
+			AdditionalIgnition: &bootstrapv1.AdditionalUserData{
+				Config: additionalIgnition,
+				Strict: true,
+			},
+		}
+	})
+
+	It("should return ignition data for worker", func() {
+		ignition, err := NewJoinWorker(input)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ignition).ToNot(BeNil())
+	})
+
+	It("should return error if input is nil", func() {
+		input = nil
+		ignition, err := NewJoinWorker(input)
+		Expect(err).To(HaveOccurred())
+		Expect(ignition).To(BeNil())
+	})
+
+	It("should return error if base userdata is nil", func() {
+		input.BaseUserData = nil
+		ignition, err := NewJoinWorker(input)
+		Expect(err).To(HaveOccurred())
+		Expect(ignition).To(BeNil())
+	})
+})
+
+var _ = Describe("NewJoinControlPlane", func() {
+	var input *ControlPlaneJoinInput
+
+	BeforeEach(func() {
+		input = &ControlPlaneJoinInput{
+			ControlPlaneInput: &cloudinit.ControlPlaneInput{
+				BaseUserData: cloudinit.BaseUserData{
+					RKE2Version: "v1.21.3+rke2r1",
+					WriteFiles: []bootstrapv1.File{
+						{
+							Path:        "/test/file",
+							Content:     "test",
+							Permissions: "0644",
+						},
+					},
+					ConfigFile: bootstrapv1.File{
+						Path:        "/test/config",
+						Content:     "test",
+						Permissions: "0644",
+					},
+				},
+			},
+			AdditionalIgnition: &bootstrapv1.AdditionalUserData{
+				Config: additionalIgnition,
+				Strict: true,
+			},
+		}
+	})
+
+	It("should return ignition data for worker", func() {
+		ignition, err := NewJoinControlPlane(input)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ignition).ToNot(BeNil())
+	})
+
+	It("should return error if input is nil", func() {
+		input = nil
+		ignition, err := NewJoinControlPlane(input)
+		Expect(err).To(HaveOccurred())
+		Expect(ignition).To(BeNil())
+	})
+
+	It("should return error if control plane input is nil", func() {
+		input.ControlPlaneInput = nil
+		ignition, err := NewJoinControlPlane(input)
+		Expect(err).To(HaveOccurred())
+		Expect(ignition).To(BeNil())
+	})
+})
+
+var _ = Describe("NewInitControlPlane", func() {
+	var input *ControlPlaneInitInput
+
+	BeforeEach(func() {
+		input = &ControlPlaneInitInput{
+			ControlPlaneInput: &cloudinit.ControlPlaneInput{
+				BaseUserData: cloudinit.BaseUserData{
+					RKE2Version: "v1.21.3+rke2r1",
+					WriteFiles: []bootstrapv1.File{
+						{
+							Path:        "/test/file",
+							Content:     "test",
+							Permissions: "0644",
+						},
+					},
+					ConfigFile: bootstrapv1.File{
+						Path:        "/test/config",
+						Content:     "test",
+						Permissions: "0644",
+					},
+				},
+			},
+			AdditionalIgnition: &bootstrapv1.AdditionalUserData{
+				Config: additionalIgnition,
+				Strict: true,
+			},
+		}
+	})
+
+	It("should return ignition data for worker", func() {
+		ignition, err := NewInitControlPlane(input)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ignition).ToNot(BeNil())
+	})
+
+	It("should return error if input is nil", func() {
+		input = nil
+		ignition, err := NewInitControlPlane(input)
+		Expect(err).To(HaveOccurred())
+		Expect(ignition).To(BeNil())
+	})
+
+	It("should return error if control plane input is nil", func() {
+		input.ControlPlaneInput = nil
+		ignition, err := NewInitControlPlane(input)
+		Expect(err).To(HaveOccurred())
+		Expect(ignition).To(BeNil())
+	})
+})
+
+var _ = Describe("getControlPlaneRKE2Commands", func() {
+	var baseUserData *cloudinit.BaseUserData
+
+	BeforeEach(func() {
+		baseUserData = &cloudinit.BaseUserData{
+			RKE2Version: "v1.21.3+rke2r1",
+		}
+	})
+
+	It("should return slice of commands", func() {
+		commands, err := getControlPlaneRKE2Commands(baseUserData)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(commands).To(HaveLen(3))
+		Expect(commands).To(ContainElements(fmt.Sprintf(controlPlaneCommand, baseUserData.RKE2Version), serverSystemdServices[0], serverSystemdServices[1]))
+	})
+
+	It("should return slice of commands with air gapped", func() {
+		baseUserData.AirGapped = true
+		commands, err := getControlPlaneRKE2Commands(baseUserData)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(commands).To(HaveLen(3))
+		Expect(commands).To(ContainElements(airGappedControlPlaneCommand, serverSystemdServices[0], serverSystemdServices[1]))
+	})
+
+	It("should return error if base userdata is nil", func() {
+		baseUserData = nil
+		commands, err := getControlPlaneRKE2Commands(baseUserData)
+		Expect(err).To(HaveOccurred())
+		Expect(commands).To(BeNil())
+	})
+
+	It("should return error if rke2 version is not set", func() {
+		baseUserData.RKE2Version = ""
+		commands, err := getControlPlaneRKE2Commands(baseUserData)
+		Expect(err).To(HaveOccurred())
+		Expect(commands).To(BeNil())
+	})
+})
+
+var _ = Describe("getWorkerRKE2Commands", func() {
+	var baseUserData *cloudinit.BaseUserData
+
+	BeforeEach(func() {
+		baseUserData = &cloudinit.BaseUserData{
+			RKE2Version: "v1.21.3+rke2r1",
+			AirGapped:   false,
+		}
+	})
+
+	It("should return slice of commands", func() {
+		commands, err := getWorkerRKE2Commands(baseUserData)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(commands).To(HaveLen(3))
+		Expect(commands).To(ContainElements(fmt.Sprintf(workerCommand, baseUserData.RKE2Version), workerSystemdServices[0], workerSystemdServices[1]))
+	})
+
+	It("should return slice of commands with air gapped", func() {
+		baseUserData.AirGapped = true
+		commands, err := getWorkerRKE2Commands(baseUserData)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(commands).To(HaveLen(3))
+		Expect(commands).To(ContainElements(airGappedWorkerCommand, workerSystemdServices[0], workerSystemdServices[1]))
+	})
+
+	It("should return error if base userdata is nil", func() {
+		baseUserData = nil
+		commands, err := getWorkerRKE2Commands(baseUserData)
+		Expect(err).To(HaveOccurred())
+		Expect(commands).To(BeNil())
+	})
+
+	It("should return error if rke2 version is not set", func() {
+		baseUserData.RKE2Version = ""
+		commands, err := getWorkerRKE2Commands(baseUserData)
+		Expect(err).To(HaveOccurred())
+		Expect(commands).To(BeNil())
+	})
+})

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/flatcar/container-linux-config-transpiler v0.9.4
+	github.com/flatcar/ignition v0.36.2
 	github.com/go-logr/logr v1.2.3
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/ginkgo/v2 v2.9.1
@@ -59,7 +60,6 @@ require (
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
-	github.com/flatcar/ignition v0.36.2 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-logr/zapr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect

--- a/samples/aws/README.md
+++ b/samples/aws/README.md
@@ -141,3 +141,34 @@ Cluster/rke2-aws                                              True              
   └─MachineDeployment/rke2-aws-md-0                           True                     18m
     └─2 Machines...                                           True                     19m    See rke2-aws-md-0-6d47bf584d-g2ljz, rke2-aws-md-0-6d47bf584d-m9z8h
 ```
+
+## Ignition based bootstrap
+
+Make sure that `BootstrapFormatIgnition` feature gate is enable for CAPA manager, you can do it
+by changing flag in the CAPA manager deployment:
+
+```yaml
+containers:
+- args:
+  - --feature-gates=EKS=true,EKSEnableIAM=false,EKSAllowAddRoles=false,EKSFargate=false,MachinePool=false,EventBridgeInstanceState=false,AutoControllerIdentityCreator=true,BootstrapFormatIgnition=true,ExternalResourceGC=false
+  ...
+  name: manager
+```
+or by setting the following environment variable before installing CAPA with `clusterctl`:
+
+```bash
+export BOOTSTRAP_FORMAT_IGNITION=true
+```
+
+For the Ignition based bootstrap, you will also need to set the following environment variables:
+
+```bash
+export AWS_S3_BUCKET_NAME=<YOUR_AWS_S3_BUCKET_NAME>
+```
+
+Now you can generate manifests from the cluster template:
+
+```bash
+clusterctl generate cluster --from https://github.com/rancher-sandbox/cluster-api-provider-rke2/blob/main/samples/aws/ignition-external/cluster-template-aws-ignition-external-cloud-provider.yaml -n example-aws rke2-aws > aws-rke2-clusterctl.yaml
+```
+

--- a/samples/aws/ignition-external/cluster-template-aws-ignition-external-cloud-provider.yaml
+++ b/samples/aws/ignition-external/cluster-template-aws-ignition-external-cloud-provider.yaml
@@ -1,0 +1,1000 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${CABPR_NAMESPACE}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    ccm: external
+    cni: ${CLUSTER_NAME}-crs-0
+    csi: external
+  name: ${CLUSTER_NAME}
+  namespace: ${CABPR_NAMESPACE}
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/16
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: RKE2ControlPlane
+    name: ${CLUSTER_NAME}-control-plane
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    kind: AWSCluster
+    name: ${CLUSTER_NAME}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSCluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${CABPR_NAMESPACE}
+spec:
+  network:
+    vpc:
+      availabilityZoneUsageLimit: 1
+  bastion:
+    enabled: true
+  region: ${AWS_REGION}
+  sshKeyName: ${AWS_SSH_KEY_NAME}
+  s3Bucket:
+    controlPlaneIAMInstanceProfile: control-plane.cluster-api-provider-aws.sigs.k8s.io
+    name: "${AWS_S3_BUCKET_NAME}"
+    nodesIAMInstanceProfiles:
+    - nodes.cluster-api-provider-aws.sigs.k8s.io
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+kind: RKE2ControlPlane
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: ${CABPR_NAMESPACE}
+spec: 
+  preRKE2Commands:
+  - sudo hostnamectl set-hostname $(curl -s http://169.254.169.254/1.0/meta-data/hostname)
+  replicas: ${CABPR_CP_REPLICAS}
+  agentConfig:
+    format: ignition
+    version: ${KUBERNETES_VERSION}+rke2r1
+  serverConfig:
+    cni: calico
+    cloudProviderName: external
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: AWSMachineTemplate
+    name: ${CLUSTER_NAME}-control-plane
+  nodeDrainTimeout: 2m
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: ${CABPR_NAMESPACE}
+spec:
+  template:
+    spec:
+      iamInstanceProfile: control-plane.cluster-api-provider-aws.sigs.k8s.io
+      instanceType: ${AWS_CONTROL_PLANE_MACHINE_TYPE}
+      sshKeyName: ${AWS_SSH_KEY_NAME}
+      rootVolume:
+        size: 50
+      imageLookupBaseOS: flatcar-stable
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+  namespace: ${CABPR_NAMESPACE}
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${CABPR_WK_REPLICAS}
+  selector:
+    matchLabels: null
+  template:
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: RKE2ConfigTemplate
+          name: ${CLUSTER_NAME}-md-0
+      clusterName: ${CLUSTER_NAME}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: AWSMachineTemplate
+        name: ${CLUSTER_NAME}-md-0
+      version: ${KUBERNETES_VERSION}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+  namespace: ${CABPR_NAMESPACE}
+spec:
+  template:
+    spec:
+      iamInstanceProfile: nodes.cluster-api-provider-aws.sigs.k8s.io
+      instanceType: ${AWS_NODE_MACHINE_TYPE}
+      sshKeyName: ${AWS_SSH_KEY_NAME}
+      rootVolume: 
+        size: 50
+      imageLookupBaseOS: flatcar-stable
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
+kind: RKE2ConfigTemplate
+metadata:
+  namespace: ${CABPR_NAMESPACE}
+  name: ${CLUSTER_NAME}-md-0
+spec: 
+  template:
+    spec:
+      preRKE2Commands:
+      - sudo hostnamectl set-hostname $(curl -s http://169.254.169.254/1.0/meta-data/hostname)
+      agentConfig:
+        format: ignition
+        version: ${KUBERNETES_VERSION}+rke2r1
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: crs-ccm
+  namespace: ${CABPR_NAMESPACE}
+spec:
+  clusterSelector:
+    matchLabels:
+      ccm: external
+  resources:
+  - kind: ConfigMap
+    name: cloud-controller-manager-addon
+  strategy: ApplyOnce
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: crs-csi
+  namespace: ${CABPR_NAMESPACE}
+spec:
+  clusterSelector:
+    matchLabels:
+      csi: external
+  resources:
+  - kind: ConfigMap
+    name: aws-ebs-csi-driver-addon
+  strategy: ApplyOnce
+---
+apiVersion: v1
+data:
+  aws-ccm-external.yaml: |
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      name: aws-cloud-controller-manager
+      namespace: kube-system
+      labels:
+        k8s-app: aws-cloud-controller-manager
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: aws-cloud-controller-manager
+      updateStrategy:
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            k8s-app: aws-cloud-controller-manager
+        spec:
+          nodeSelector:
+            node-role.kubernetes.io/master: "true"
+          tolerations:
+            - key: node.cloudprovider.kubernetes.io/uninitialized
+              value: "true"
+              effect: NoSchedule
+            - key: node-role.kubernetes.io/master
+              effect: NoSchedule
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/control-plane
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: node-role.kubernetes.io/control-plane
+                        operator: Exists
+                  - matchExpressions:
+                      - key: node-role.kubernetes.io/master
+                        operator: Exists
+          serviceAccountName: cloud-controller-manager
+          containers:
+            - name: aws-cloud-controller-manager
+              image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.20.0-alpha.0
+              args:
+                - --v=2
+              resources:
+                requests:
+                  cpu: 200m
+          hostNetwork: true
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: cloud-controller-manager
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: cloud-controller-manager:apiserver-authentication-reader
+      namespace: kube-system
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: extension-apiserver-authentication-reader
+    subjects:
+      - apiGroup: ""
+        kind: ServiceAccount
+        name: cloud-controller-manager
+        namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: system:cloud-controller-manager
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - events
+        verbs:
+          - create
+          - patch
+          - update
+      - apiGroups:
+          - ""
+        resources:
+          - nodes
+        verbs:
+          - '*'
+      - apiGroups:
+          - ""
+        resources:
+          - nodes/status
+        verbs:
+          - patch
+      - apiGroups:
+          - ""
+        resources:
+          - services
+        verbs:
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - services/status
+        verbs:
+          - list
+          - patch
+          - update
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts
+        verbs:
+          - create
+      - apiGroups:
+          - ""
+        resources:
+          - persistentvolumes
+        verbs:
+          - get
+          - list
+          - update
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - configmaps
+        verbs:
+          - list
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - endpoints
+        verbs:
+          - create
+          - get
+          - list
+          - watch
+          - update
+      - apiGroups:
+          - coordination.k8s.io
+        resources:
+          - leases
+        verbs:
+          - create
+          - get
+          - list
+          - watch
+          - update
+    ---
+    kind: ClusterRoleBinding
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      name: system:cloud-controller-manager
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: system:cloud-controller-manager
+    subjects:
+      - apiGroup: ""
+        kind: ServiceAccount
+        name: cloud-controller-manager
+        namespace: kube-system
+kind: ConfigMap
+metadata:
+  annotations:
+    note: generated
+  labels:
+    type: generated
+  name: cloud-controller-manager-addon
+  namespace: ${CABPR_NAMESPACE}
+---
+apiVersion: v1
+data:
+  aws-ebs-csi-external.yaml: |-
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: aws-secret
+      namespace: kube-system
+    stringData:
+      key_id: ""
+      access_key: ""
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/name: aws-ebs-csi-driver
+      name: ebs-csi-controller-sa
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/name: aws-ebs-csi-driver
+      name: ebs-csi-node-sa
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app.kubernetes.io/name: aws-ebs-csi-driver
+      name: ebs-external-attacher-role
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - persistentvolumes
+        verbs:
+          - get
+          - list
+          - watch
+          - update
+          - patch
+      - apiGroups:
+          - ""
+        resources:
+          - nodes
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - csi.storage.k8s.io
+        resources:
+          - csinodeinfos
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - storage.k8s.io
+        resources:
+          - volumeattachments
+        verbs:
+          - get
+          - list
+          - watch
+          - update
+          - patch
+      - apiGroups:
+          - storage.k8s.io
+        resources:
+          - volumeattachments/status
+        verbs:
+          - patch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app.kubernetes.io/name: aws-ebs-csi-driver
+      name: ebs-external-provisioner-role
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - persistentvolumes
+        verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+      - apiGroups:
+          - ""
+        resources:
+          - persistentvolumeclaims
+        verbs:
+          - get
+          - list
+          - watch
+          - update
+      - apiGroups:
+          - storage.k8s.io
+        resources:
+          - storageclasses
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - events
+        verbs:
+          - list
+          - watch
+          - create
+          - update
+          - patch
+      - apiGroups:
+          - snapshot.storage.k8s.io
+        resources:
+          - volumesnapshots
+        verbs:
+          - get
+          - list
+      - apiGroups:
+          - snapshot.storage.k8s.io
+        resources:
+          - volumesnapshotcontents
+        verbs:
+          - get
+          - list
+      - apiGroups:
+          - storage.k8s.io
+        resources:
+          - csinodes
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - nodes
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - coordination.k8s.io
+        resources:
+          - leases
+        verbs:
+          - get
+          - watch
+          - list
+          - delete
+          - update
+          - create
+      - apiGroups:
+          - storage.k8s.io
+        resources:
+          - volumeattachments
+        verbs:
+          - get
+          - list
+          - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app.kubernetes.io/name: aws-ebs-csi-driver
+      name: ebs-external-resizer-role
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - persistentvolumes
+        verbs:
+          - get
+          - list
+          - watch
+          - update
+          - patch
+      - apiGroups:
+          - ""
+        resources:
+          - persistentvolumeclaims
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - persistentvolumeclaims/status
+        verbs:
+          - update
+          - patch
+      - apiGroups:
+          - storage.k8s.io
+        resources:
+          - storageclasses
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - events
+        verbs:
+          - list
+          - watch
+          - create
+          - update
+          - patch
+      - apiGroups:
+          - ""
+        resources:
+          - pods
+        verbs:
+          - get
+          - list
+          - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app.kubernetes.io/name: aws-ebs-csi-driver
+      name: ebs-external-snapshotter-role
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - events
+        verbs:
+          - list
+          - watch
+          - create
+          - update
+          - patch
+      - apiGroups:
+          - ""
+        resources:
+          - secrets
+        verbs:
+          - get
+          - list
+      - apiGroups:
+          - snapshot.storage.k8s.io
+        resources:
+          - volumesnapshotclasses
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - snapshot.storage.k8s.io
+        resources:
+          - volumesnapshotcontents
+        verbs:
+          - create
+          - get
+          - list
+          - watch
+          - update
+          - delete
+      - apiGroups:
+          - snapshot.storage.k8s.io
+        resources:
+          - volumesnapshotcontents/status
+        verbs:
+          - update
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      labels:
+        app.kubernetes.io/name: aws-ebs-csi-driver
+      name: ebs-csi-attacher-binding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: ebs-external-attacher-role
+    subjects:
+      - kind: ServiceAccount
+        name: ebs-csi-controller-sa
+        namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      labels:
+        app.kubernetes.io/name: aws-ebs-csi-driver
+      name: ebs-csi-provisioner-binding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: ebs-external-provisioner-role
+    subjects:
+      - kind: ServiceAccount
+        name: ebs-csi-controller-sa
+        namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      labels:
+        app.kubernetes.io/name: aws-ebs-csi-driver
+      name: ebs-csi-resizer-binding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: ebs-external-resizer-role
+    subjects:
+      - kind: ServiceAccount
+        name: ebs-csi-controller-sa
+        namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      labels:
+        app.kubernetes.io/name: aws-ebs-csi-driver
+      name: ebs-csi-snapshotter-binding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: ebs-external-snapshotter-role
+    subjects:
+      - kind: ServiceAccount
+        name: ebs-csi-controller-sa
+        namespace: kube-system
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/name: aws-ebs-csi-driver
+      name: ebs-csi-controller
+      namespace: kube-system
+    spec:
+      replicas: 2
+      selector:
+        matchLabels:
+          app: ebs-csi-controller
+          app.kubernetes.io/name: aws-ebs-csi-driver
+      template:
+        metadata:
+          labels:
+            app: ebs-csi-controller
+            app.kubernetes.io/name: aws-ebs-csi-driver
+        spec:
+          containers:
+            - args:
+                - --endpoint=$(CSI_ENDPOINT)
+                - --logtostderr
+                - --v=2
+              env:
+                - name: CSI_ENDPOINT
+                  value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+                - name: CSI_NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      key: key_id
+                      name: aws-secret
+                      optional: true
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      key: access_key
+                      name: aws-secret
+                      optional: true
+              image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.2.0
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /healthz
+                  port: healthz
+                initialDelaySeconds: 10
+                periodSeconds: 10
+                timeoutSeconds: 3
+              name: ebs-plugin
+              ports:
+                - containerPort: 9808
+                  name: healthz
+                  protocol: TCP
+              readinessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /healthz
+                  port: healthz
+                initialDelaySeconds: 10
+                periodSeconds: 10
+                timeoutSeconds: 3
+              volumeMounts:
+                - mountPath: /var/lib/csi/sockets/pluginproxy/
+                  name: socket-dir
+            - args:
+                - --csi-address=$(ADDRESS)
+                - --v=2
+                - --feature-gates=Topology=true
+                - --extra-create-metadata
+                - --leader-election=true
+                - --default-fstype=ext4
+              env:
+                - name: ADDRESS
+                  value: /var/lib/csi/sockets/pluginproxy/csi.sock
+              image: registry.k8s.io/sig-storage/csi-provisioner:v2.1.1
+              name: csi-provisioner
+              volumeMounts:
+                - mountPath: /var/lib/csi/sockets/pluginproxy/
+                  name: socket-dir
+            - args:
+                - --csi-address=$(ADDRESS)
+                - --v=2
+                - --leader-election=true
+              env:
+                - name: ADDRESS
+                  value: /var/lib/csi/sockets/pluginproxy/csi.sock
+              image: registry.k8s.io/sig-storage/csi-attacher:v3.1.0
+              name: csi-attacher
+              volumeMounts:
+                - mountPath: /var/lib/csi/sockets/pluginproxy/
+                  name: socket-dir
+            - args:
+                - --csi-address=$(ADDRESS)
+                - --leader-election=true
+              env:
+                - name: ADDRESS
+                  value: /var/lib/csi/sockets/pluginproxy/csi.sock
+              image: registry.k8s.io/sig-storage/csi-snapshotter:v3.0.3
+              name: csi-snapshotter
+              volumeMounts:
+                - mountPath: /var/lib/csi/sockets/pluginproxy/
+                  name: socket-dir
+            - args:
+                - --csi-address=$(ADDRESS)
+                - --v=2
+              env:
+                - name: ADDRESS
+                  value: /var/lib/csi/sockets/pluginproxy/csi.sock
+              image: registry.k8s.io/sig-storage/csi-resizer:v1.0.0
+              imagePullPolicy: Always
+              name: csi-resizer
+              volumeMounts:
+                - mountPath: /var/lib/csi/sockets/pluginproxy/
+                  name: socket-dir
+            - args:
+                - --csi-address=/csi/csi.sock
+              image: registry.k8s.io/sig-storage/livenessprobe:v2.2.0
+              name: liveness-probe
+              volumeMounts:
+                - mountPath: /csi
+                  name: socket-dir
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-cluster-critical
+          serviceAccountName: ebs-csi-controller-sa
+          tolerations:
+            - key: CriticalAddonsOnly
+              operator: Exists
+            - effect: NoExecute
+              operator: Exists
+              tolerationSeconds: 300
+            - key: node-role.kubernetes.io/master
+              effect: NoSchedule
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/control-plane
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: node-role.kubernetes.io/control-plane
+                        operator: Exists
+                  - matchExpressions:
+                      - key: node-role.kubernetes.io/master
+                        operator: Exists
+          volumes:
+            - emptyDir: {}
+              name: socket-dir
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodDisruptionBudget
+    metadata:
+      labels:
+        app.kubernetes.io/name: aws-ebs-csi-driver
+      name: ebs-csi-controller
+      namespace: kube-system
+    spec:
+      maxUnavailable: 1
+      selector:
+        matchLabels:
+          app: ebs-csi-controller
+          app.kubernetes.io/name: aws-ebs-csi-driver
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        app.kubernetes.io/name: aws-ebs-csi-driver
+      name: ebs-csi-node
+      namespace: kube-system
+    spec:
+      selector:
+        matchLabels:
+          app: ebs-csi-node
+          app.kubernetes.io/name: aws-ebs-csi-driver
+      template:
+        metadata:
+          labels:
+            app: ebs-csi-node
+            app.kubernetes.io/name: aws-ebs-csi-driver
+        spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: eks.amazonaws.com/compute-type
+                        operator: NotIn
+                        values:
+                          - fargate
+          containers:
+            - args:
+                - node
+                - --endpoint=$(CSI_ENDPOINT)
+                - --logtostderr
+                - --v=2
+              env:
+                - name: CSI_ENDPOINT
+                  value: unix:/csi/csi.sock
+                - name: CSI_NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+              image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.2.0
+              livenessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /healthz
+                  port: healthz
+                initialDelaySeconds: 10
+                periodSeconds: 10
+                timeoutSeconds: 3
+              name: ebs-plugin
+              ports:
+                - containerPort: 9808
+                  name: healthz
+                  protocol: TCP
+              securityContext:
+                privileged: true
+              volumeMounts:
+                - mountPath: /var/lib/kubelet
+                  mountPropagation: Bidirectional
+                  name: kubelet-dir
+                - mountPath: /csi
+                  name: plugin-dir
+                - mountPath: /dev
+                  name: device-dir
+            - args:
+                - --csi-address=$(ADDRESS)
+                - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+                - --v=2
+              env:
+                - name: ADDRESS
+                  value: /csi/csi.sock
+                - name: DRIVER_REG_SOCK_PATH
+                  value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
+              image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.1.0
+              name: node-driver-registrar
+              volumeMounts:
+                - mountPath: /csi
+                  name: plugin-dir
+                - mountPath: /registration
+                  name: registration-dir
+            - args:
+                - --csi-address=/csi/csi.sock
+              image: registry.k8s.io/sig-storage/livenessprobe:v2.2.0
+              name: liveness-probe
+              volumeMounts:
+                - mountPath: /csi
+                  name: plugin-dir
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-node-critical
+          serviceAccountName: ebs-csi-node-sa
+          tolerations:
+            - key: CriticalAddonsOnly
+              operator: Exists
+            - effect: NoExecute
+              operator: Exists
+              tolerationSeconds: 300
+          volumes:
+            - hostPath:
+                path: /var/lib/kubelet
+                type: Directory
+              name: kubelet-dir
+            - hostPath:
+                path: /var/lib/kubelet/plugins/ebs.csi.aws.com/
+                type: DirectoryOrCreate
+              name: plugin-dir
+            - hostPath:
+                path: /var/lib/kubelet/plugins_registry/
+                type: Directory
+              name: registration-dir
+            - hostPath:
+                path: /dev
+                type: Directory
+              name: device-dir
+      updateStrategy:
+        rollingUpdate:
+          maxUnavailable: 10%
+        type: RollingUpdate
+    ---
+    apiVersion: storage.k8s.io/v1
+    kind: CSIDriver
+    metadata:
+      labels:
+        app.kubernetes.io/name: aws-ebs-csi-driver
+      name: ebs.csi.aws.com
+    spec:
+      attachRequired: true
+      podInfoOnMount: false
+kind: ConfigMap
+metadata:
+  annotations:
+    note: generated
+  labels:
+    type: generated
+  name: aws-ebs-csi-driver-addon
+  namespace: ${CABPR_NAMESPACE}
+--- 
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSClusterControllerIdentity
+metadata:
+  name: default
+spec:
+  allowedNamespaces:
+    list:
+      - ${CABPR_NAMESPACE}


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Add support for ignition based user data. It similar to what is implemented for kubeadm, I also added a cluster template and instructions for bootstrapping.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/rancher-sandbox/cluster-api-provider-rke2/issues/66

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [x] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
