### PR TITLE
Fix for disablePlugin field not validated correctly

### DIFF
--- a/controlplane/api/v1alpha1/rke2controlplane_types.go
+++ b/controlplane/api/v1alpha1/rke2controlplane_types.go
@@ -293,15 +293,14 @@ const (
 // DisableComponents describes components of RKE2 (Kubernetes components and plugin components) that should be disabled.
 type DisableComponents struct {
 	// KubernetesComponents is a list of Kubernetes components to disable.
-	// +kubebuilder:validation:Enum=scheduler;kubeProxy;cloudController
 	KubernetesComponents []DisabledKubernetesComponent `json:"kubernetesComponents,omitempty"`
 
 	// PluginComponents is a list of PluginComponents to disable.
-	// +kubebuilder:validation:Enum=rke2-coredns;rke2-ingress-nginx;rke2-metrics-server
 	PluginComponents []DisabledPluginComponent `json:"pluginComponents,omitempty"`
 }
 
 // DisabledKubernetesComponent is an enum field that can take one of the following values: scheduler, kubeProxy or cloudController.
+// +kubebuilder:validation:Enum=scheduler;kubeProxy;cloudController
 type DisabledKubernetesComponent string
 
 const (
@@ -316,6 +315,7 @@ const (
 )
 
 // DisabledPluginComponent selects a plugin Components to be disabled.
+// +kubebuilder:validation:Enum=rke2-coredns;rke2-ingress-nginx;rke2-metrics-server
 type DisabledPluginComponent string
 
 const (

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanes.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanes.yaml
@@ -714,26 +714,26 @@ spec:
                       kubernetesComponents:
                         description: KubernetesComponents is a list of Kubernetes
                           components to disable.
-                        enum:
-                        - scheduler
-                        - kubeProxy
-                        - cloudController
                         items:
                           description: 'DisabledKubernetesComponent is an enum field
                             that can take one of the following values: scheduler,
                             kubeProxy or cloudController.'
+                          enum:
+                          - scheduler
+                          - kubeProxy
+                          - cloudController
                           type: string
                         type: array
                       pluginComponents:
                         description: PluginComponents is a list of PluginComponents
                           to disable.
-                        enum:
-                        - rke2-coredns
-                        - rke2-ingress-nginx
-                        - rke2-metrics-server
                         items:
                           description: DisabledPluginComponent selects a plugin Components
                             to be disabled.
+                          enum:
+                          - rke2-coredns
+                          - rke2-ingress-nginx
+                          - rke2-metrics-server
                           type: string
                         type: array
                     type: object

--- a/controlplane/config/manager/manager.yaml
+++ b/controlplane/config/manager/manager.yaml
@@ -55,7 +55,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 256Mi
           requests:
             cpu: 10m
             memory: 64Mi

--- a/samples/aws/external/cluster-template-external-cloud-provider.yaml
+++ b/samples/aws/external/cluster-template-external-cloud-provider.yaml
@@ -72,7 +72,7 @@ spec:
       instanceType: ${AWS_CONTROL_PLANE_MACHINE_TYPE}
       sshKeyName: ${AWS_SSH_KEY_NAME}
       rootVolume:
-        size: 50
+        size: 51
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
@@ -120,8 +120,8 @@ metadata:
 spec: 
   template:
     spec:
-      preRKE2Commands:
-      - sudo hostnamectl set-hostname $(curl -s http://169.254.169.254/1.0/meta-data/hostname)
+      #preRKE2Commands:
+      #- sudo hostnamectl set-hostname $(curl -s http://169.254.169.254/1.0/meta-data/hostname)
       agentConfig:
         version: ${KUBERNETES_VERSION}+rke2r1
 ---

--- a/samples/docker/disable-components/rke2-sample.yaml
+++ b/samples/docker/disable-components/rke2-sample.yaml
@@ -1,0 +1,108 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${CABPR_NAMESPACE}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster 
+metadata:
+  namespace: ${CABPR_NAMESPACE}
+  name: ${CLUSTER_NAME} 
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - 10.45.0.0/16
+    services:
+      cidrBlocks:
+      - 10.46.0.0/16
+    serviceDomain: cluster.local
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+    kind: RKE2ControlPlane
+    name: ${CLUSTER_NAME}-control-plane
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: DockerCluster
+    name: ${CLUSTER_NAME}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerCluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${CABPR_NAMESPACE}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+kind: RKE2ControlPlane
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: ${CABPR_NAMESPACE}
+spec: 
+  replicas: ${CABPR_CP_REPLICAS}
+  agentConfig:
+    version: ${KUBERNETES_VERSION}+rke2r1
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: DockerMachineTemplate
+    name: controlplane
+  serverConfig:
+   disableComponents:
+      pluginComponents:
+      - "rke2-ingress-nginx"
+  nodeDrainTimeout: 2m
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerMachineTemplate
+metadata:
+  name: controlplane
+  namespace: ${CABPR_NAMESPACE}
+spec:
+  template:
+    spec: {} 
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: worker-md-0
+  namespace: ${CABPR_NAMESPACE}
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${CABPR_WK_REPLICAS}
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+  template:
+    spec:
+      version: ${KUBERNETES_VERSION}
+      clusterName: ${CLUSTER_NAME}
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
+          kind: RKE2ConfigTemplate
+          name: ${CLUSTER_NAME}-agent
+          namespace: ${CABPR_NAMESPACE}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: DockerMachineTemplate
+        name: worker
+        namespace: ${CABPR_NAMESPACE}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerMachineTemplate
+metadata:
+  name: worker
+  namespace: ${CABPR_NAMESPACE}
+spec:
+  template:
+    spec: {} 
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
+kind: RKE2ConfigTemplate
+metadata:
+  namespace: ${CABPR_NAMESPACE}
+  name: ${CLUSTER_NAME}-agent
+spec: 
+  template:
+    spec:
+      agentConfig:
+        version: ${KUBERNETES_VERSION}+rke2r1


### PR DESCRIPTION
Signed-off-by: Mohamed Belgaied Hassine <belgaied2@hotmail.com>

<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
This PR fixes an issue with Kubebuilder validation of the field `disablePlugin` field of the `RKE2ControlPlane` resource.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #128

**Special notes for your reviewer**:
This is a simple change in the location of kubebuilder annotation for the enum validation.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
