### PR TITLE
feat: support different registration methods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ GOLANGCI_LINT_VER := v1.49.0
 GOLANGCI_LINT_BIN := golangci-lint
 GOLANGCI_LINT := $(abspath $(TOOLS_BIN_DIR)/$(GOLANGCI_LINT_BIN))
 
-GINKGO_VER := v2.9.1
+GINKGO_VER := v2.9.4
 GINKGO_BIN := ginkgo
 GINKGO := $(abspath $(TOOLS_BIN_DIR)/$(GINKGO_BIN)-$(GINKGO_VER))
 GINKGO_PKG := github.com/onsi/ginkgo/v2/ginkgo

--- a/controlplane/api/v1alpha1/rke2controlplane_types.go
+++ b/controlplane/api/v1alpha1/rke2controlplane_types.go
@@ -60,6 +60,17 @@ type RKE2ControlPlaneSpec struct {
 	// NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
 	// +optional
 	NodeDrainTimeout *metav1.Duration `json:"nodeDrainTimeout,omitempty"`
+
+	// RegistrationMethod is the method to use for registering nodes into the RKE2 cluster.
+	// +kubebuilder:validation:Enum=internal-first;internal-only-ips;external-only-ips;address
+	// +kubebuilder:default=internal-first
+	// +optional
+	RegistrationMethod RegistrationMethod `json:"registrationMethod"`
+
+	// RegistrationAddress is an explicit address to use when registering a node. This is required if
+	// the registration type is "address". Its for scenarios where a load-balancer or VIP is used.
+	// +optional
+	RegistrationAddress string `json:"registrationAddress,omitempty"`
 }
 
 // RKE2ServerConfig specifies configuration for the agent nodes.

--- a/controlplane/api/v1alpha1/types.go
+++ b/controlplane/api/v1alpha1/types.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2023 SUSE.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+// RegistrationMethod defines the methods to use for registering a new node in a cluster.
+type RegistrationMethod string
+
+var (
+	// RegistrationMethodFavourInternalIPs is a registration method where the IP address of the control plane
+	// machines are used for registration. For each machine it will check if there is an internal IP address
+	// and will use that. If there is no internal IP address it will use the external IP address if there is one.
+	RegistrationMethodFavourInternalIPs = RegistrationMethod("internal-first")
+	// RegistrationMethodInternalIPs is a registration method where the internal IP address of the control plane
+	// machines are used for registration.
+	RegistrationMethodInternalIPs = RegistrationMethod("internal-only-ips")
+	// RegistrationMethodExternalIPs is a registration method where the external IP address of the control plane
+	// machines are used for registration.
+	RegistrationMethodExternalIPs = RegistrationMethod("external-only-ips")
+	// RegistrationMethodAddress is a registration method where an explicit address supplied at cluster creation
+	// time is used for registration. This is for use in LB or VIP scenarios.
+	RegistrationMethodAddress = RegistrationMethod("address")
+)

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanes.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanes.yaml
@@ -567,6 +567,21 @@ spec:
                     description: Mirrors are namespace to mirror mapping for all namespaces.
                     type: object
                 type: object
+              registrationAddress:
+                description: RegistrationAddress is an explicit address to use when
+                  registering a node. This is required if the registration type is
+                  "address". Its for scenarios where a load-balancer or VIP is used.
+                type: string
+              registrationMethod:
+                default: internal-first
+                description: RegistrationMethod is the method to use for registering
+                  nodes into the RKE2 cluster.
+                enum:
+                - internal-first
+                - internal-only-ips
+                - external-only-ips
+                - address
+                type: string
               replicas:
                 description: Replicas is the number of replicas for the Control Plane.
                 format: int32

--- a/docs/registration-methods.md
+++ b/docs/registration-methods.md
@@ -1,0 +1,58 @@
+# Node Registration Methods
+
+The provider supports multiple methods for registering a new node into the cluster.
+
+## Usage
+
+The method to use is specified on the **RKEControlPlane** within the **spec**. If no method is supplied then the default method of **internal-first** will be used.
+
+> You cannot change the registration method after creation.
+
+An example of using a different method:
+
+```yaml
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+kind: RKE2ControlPlane
+metadata:
+  name: test1-control-plane
+  namespace: default
+spec:
+  agentConfig:
+    version: v1.26.4+rke2r1
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: DockerMachineTemplate
+    name: controlplane
+  nodeDrainTimeout: 2m
+  replicas: 3
+  serverConfig:
+    cni: calico
+  registrationMethod: "address"
+  registrationAddress: "172.19.0.3"
+```
+
+## Registration Methods
+
+### internal-first
+
+For each CAPI `Machine` that is used for the control plane,  we take the **internal** ip address from `Machine.status.addresses` if it exists. If there is no **internal** ip for a machine then we will use an **external** address instead. For the ip address found for a machine then we add it to  `RKEControlPlane.status.availableServerIPs`.
+
+The first IP address listed in `RKEControlPlane.status.availableServerIPs` is then used for the join.
+
+### internal-only-ips
+
+For each CAPI `Machine` that is used for the control plane,  we take the **internal** ip address from `Machine.status.addresses` if it exists and then we add it to  `RKEControlPlane.status.availableServerIPs`.
+
+The first IP address listed in `RKEControlPlane.status.availableServerIPs` is then used for the join.
+
+### external-only-ips
+
+For each CAPI `Machine` that is used for the control plane,  we take the **external** ip address from `Machine.status.addresses` if it exists and then we add it to  `RKEControlPlane.status.availableServerIPs`.
+
+The first IP address listed in `RKEControlPlane.status.availableServerIPs` is then used for the join.
+
+### address
+
+For this method you must supply an address in the control plane spec (i.e. `RKE2ControlPlane.spec.registrationAddress`). This address is then used for the join.
+
+With this method its expected that you have a load balancer / VIP solution sitting in front of all the control plane machines and all the join requests will be routed via this.

--- a/pkg/registration/registration.go
+++ b/pkg/registration/registration.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2023 SUSE.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registration
+
+import (
+	"errors"
+	"fmt"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/collections"
+
+	controlplanev1 "github.com/rancher-sandbox/cluster-api-provider-rke2/controlplane/api/v1alpha1"
+)
+
+// GetRegistrationAddresses is a function type that is used to provide different implementations of
+// getting the addresses just when registering a new node into a cluster.
+type GetRegistrationAddresses func(rcp *controlplanev1.RKE2ControlPlane, cpMachines collections.Machines) ([]string, error)
+
+// NewRegistrationMethod returns the function for the registration addresses based on the passed method name.
+func NewRegistrationMethod(method string) (GetRegistrationAddresses, error) {
+	switch method {
+	case "internal-first":
+		return registrationMethodWithFilter(filterInternalFirst), nil
+	case "internal-only-ips":
+		return registrationMethodWithFilter(filterInternalOnly), nil
+	case "external-only-ips":
+		return registrationMethodWithFilter(filterExternalOnly), nil
+	case "address":
+		return registrationMethodAddress, nil
+	default:
+		return nil, fmt.Errorf("unsupported registration method: %s", method)
+	}
+}
+
+func registrationMethodWithFilter(filter addressFilter) GetRegistrationAddresses {
+	return func(rcp *controlplanev1.RKE2ControlPlane, availableMachines collections.Machines) ([]string, error) {
+		validIPAddresses := []string{}
+
+		for _, availableMachine := range availableMachines {
+			ip := filter(availableMachine)
+			if ip != "" {
+				validIPAddresses = append(validIPAddresses, ip)
+			}
+		}
+
+		return validIPAddresses, nil
+	}
+}
+
+func registrationMethodAddress(rcp *controlplanev1.RKE2ControlPlane, availableMachines collections.Machines) ([]string, error) {
+	validIPAddresses := []string{}
+
+	validIPAddresses = append(validIPAddresses, rcp.Spec.RegistrationAddress)
+
+	if len(validIPAddresses) == 0 {
+		return nil, errors.New("no registration address supplied")
+	}
+
+	return validIPAddresses, nil
+}
+
+type addressFilter func(machine *clusterv1.Machine) string
+
+func filterInternalFirst(machine *clusterv1.Machine) string {
+	for _, address := range machine.Status.Addresses {
+		switch address.Type {
+		case clusterv1.MachineInternalIP:
+			if address.Address != "" {
+				return address.Address
+			}
+		case clusterv1.MachineExternalIP:
+			if address.Address != "" {
+				return address.Address
+			}
+		}
+	}
+
+	return ""
+}
+
+func filterInternalOnly(machine *clusterv1.Machine) string {
+	for _, address := range machine.Status.Addresses {
+		if address.Type == clusterv1.MachineInternalIP {
+			if address.Address != "" {
+				return address.Address
+			}
+		}
+	}
+
+	return ""
+}
+
+func filterExternalOnly(machine *clusterv1.Machine) string {
+	for _, address := range machine.Status.Addresses {
+		if address.Type == clusterv1.MachineExternalIP {
+			if address.Address != "" {
+				return address.Address
+			}
+		}
+	}
+
+	return ""
+}

--- a/pkg/registration/registration_test.go
+++ b/pkg/registration/registration_test.go
@@ -1,0 +1,324 @@
+/*
+Copyright 2023 SUSE.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registration_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/collections"
+
+	controlplanev1 "github.com/rancher-sandbox/cluster-api-provider-rke2/controlplane/api/v1alpha1"
+	"github.com/rancher-sandbox/cluster-api-provider-rke2/pkg/registration"
+)
+
+func TestNewRegistrationMethod(t *testing.T) {
+	testCases := []struct {
+		name        string
+		expectError bool
+	}{
+		{
+			name:        "internal-first",
+			expectError: false,
+		},
+		{
+			name:        "internal-only-ips",
+			expectError: false,
+		},
+		{
+			name:        "external-only-ips",
+			expectError: false,
+		},
+		{
+			name:        "address",
+			expectError: false,
+		},
+		{
+			name:        "unknownmethod",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			regMethod, err := registration.NewRegistrationMethod(tc.name)
+			if !tc.expectError {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(regMethod).ToNot(BeNil())
+			} else {
+				g.Expect(err).To(HaveOccurred())
+			}
+		})
+	}
+}
+
+func TestInternalFirstMethod(t *testing.T) {
+	testCases := []struct {
+		name              string
+		rcp               *controlplanev1.RKE2ControlPlane
+		machines          []*clusterv1.Machine
+		expectedAddresses []string
+	}{
+		{
+			name: "only internal",
+			rcp:  createControlPlane(string(controlplanev1.RegistrationMethodFavourInternalIPs), ""),
+			machines: []*clusterv1.Machine{
+				createMachine("machine1", []string{"10.0.0.3"}, nil),
+			},
+			expectedAddresses: []string{"10.0.0.3"},
+		},
+		{
+			name: "internal and external",
+			rcp:  createControlPlane(string(controlplanev1.RegistrationMethodFavourInternalIPs), ""),
+			machines: []*clusterv1.Machine{
+				createMachine("machine1", []string{"10.0.0.3"}, []string{"201.55.56.77"}),
+			},
+			expectedAddresses: []string{"10.0.0.3"},
+		},
+		{
+			name: "multiple machines one with each type",
+			rcp:  createControlPlane(string(controlplanev1.RegistrationMethodFavourInternalIPs), ""),
+			machines: []*clusterv1.Machine{
+				createMachine("machine1", nil, []string{"201.55.56.77"}),
+				createMachine("machine2", []string{"10.0.0.3"}, nil),
+			},
+			expectedAddresses: []string{"201.55.56.77", "10.0.0.3"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			regMethod, err := registration.NewRegistrationMethod(string(controlplanev1.RegistrationMethodFavourInternalIPs))
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(regMethod).NotTo(BeNil())
+
+			col := collections.FromMachines(tc.machines...)
+
+			actualAddresses, err := regMethod(tc.rcp, col)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(actualAddresses).To(BeComparableTo(tc.expectedAddresses))
+
+		})
+	}
+}
+
+func TestInternalOnlyMethod(t *testing.T) {
+	testCases := []struct {
+		name              string
+		rcp               *controlplanev1.RKE2ControlPlane
+		machines          []*clusterv1.Machine
+		expectedAddresses []string
+	}{
+		{
+			name: "only internal",
+			rcp:  createControlPlane(string(controlplanev1.RegistrationMethodInternalIPs), ""),
+			machines: []*clusterv1.Machine{
+				createMachine("machine1", []string{"10.0.0.3"}, nil),
+			},
+			expectedAddresses: []string{"10.0.0.3"},
+		},
+		{
+			name: "internal and external",
+			rcp:  createControlPlane(string(controlplanev1.RegistrationMethodInternalIPs), ""),
+			machines: []*clusterv1.Machine{
+				createMachine("machine1", []string{"10.0.0.3"}, []string{"201.55.56.77"}),
+			},
+			expectedAddresses: []string{"10.0.0.3"},
+		},
+		{
+			name: "multiple machines one with each type",
+			rcp:  createControlPlane(string(controlplanev1.RegistrationMethodInternalIPs), ""),
+			machines: []*clusterv1.Machine{
+				createMachine("machine1", nil, []string{"201.55.56.77"}),
+				createMachine("machine2", []string{"10.0.0.3"}, nil),
+			},
+			expectedAddresses: []string{"10.0.0.3"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			regMethod, err := registration.NewRegistrationMethod(string(controlplanev1.RegistrationMethodInternalIPs))
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(regMethod).NotTo(BeNil())
+
+			col := collections.FromMachines(tc.machines...)
+
+			actualAddresses, err := regMethod(tc.rcp, col)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(actualAddresses).To(BeComparableTo(tc.expectedAddresses))
+
+		})
+	}
+}
+
+func TestExternalOnlyMethod(t *testing.T) {
+	testCases := []struct {
+		name              string
+		rcp               *controlplanev1.RKE2ControlPlane
+		machines          []*clusterv1.Machine
+		expectedAddresses []string
+	}{
+		{
+			name: "only internal",
+			rcp:  createControlPlane(string(controlplanev1.RegistrationMethodExternalIPs), ""),
+			machines: []*clusterv1.Machine{
+				createMachine("machine1", []string{"10.0.0.3"}, nil),
+			},
+			expectedAddresses: []string{},
+		},
+		{
+			name: "internal and external",
+			rcp:  createControlPlane(string(controlplanev1.RegistrationMethodExternalIPs), ""),
+			machines: []*clusterv1.Machine{
+				createMachine("machine1", []string{"10.0.0.3"}, []string{"201.55.56.77"}),
+			},
+			expectedAddresses: []string{"201.55.56.77"},
+		},
+		{
+			name: "multiple machines one with each type",
+			rcp:  createControlPlane(string(controlplanev1.RegistrationMethodExternalIPs), ""),
+			machines: []*clusterv1.Machine{
+				createMachine("machine1", nil, []string{"201.55.56.77"}),
+				createMachine("machine2", []string{"10.0.0.3"}, nil),
+			},
+			expectedAddresses: []string{"201.55.56.77"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			regMethod, err := registration.NewRegistrationMethod(string(controlplanev1.RegistrationMethodExternalIPs))
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(regMethod).NotTo(BeNil())
+
+			col := collections.FromMachines(tc.machines...)
+
+			actualAddresses, err := regMethod(tc.rcp, col)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(actualAddresses).To(BeComparableTo(tc.expectedAddresses))
+
+		})
+	}
+}
+
+func TestAddressMethod(t *testing.T) {
+	testCases := []struct {
+		name     string
+		rcp      *controlplanev1.RKE2ControlPlane
+		machines []*clusterv1.Machine
+	}{
+		{
+			name: "only internal",
+			rcp:  createControlPlane(string(controlplanev1.RegistrationMethodAddress), "100.100.100.100"),
+			machines: []*clusterv1.Machine{
+				createMachine("machine1", []string{"10.0.0.3"}, nil),
+			},
+		},
+		{
+			name: "internal and external",
+			rcp:  createControlPlane(string(controlplanev1.RegistrationMethodAddress), "100.100.100.100"),
+			machines: []*clusterv1.Machine{
+				createMachine("machine1", []string{"10.0.0.3"}, []string{"201.55.56.77"}),
+			},
+		},
+		{
+			name: "multiple machines one with each type",
+			rcp:  createControlPlane(string(controlplanev1.RegistrationMethodAddress), "100.100.100.100"),
+			machines: []*clusterv1.Machine{
+				createMachine("machine1", nil, []string{"201.55.56.77"}),
+				createMachine("machine2", []string{"10.0.0.3"}, nil),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			regMethod, err := registration.NewRegistrationMethod(string(controlplanev1.RegistrationMethodAddress))
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(regMethod).NotTo(BeNil())
+
+			col := collections.FromMachines(tc.machines...)
+
+			actualAddresses, err := regMethod(tc.rcp, col)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			expectedAddresses := []string{"100.100.100.100"}
+
+			g.Expect(actualAddresses).To(BeComparableTo(expectedAddresses))
+
+		})
+	}
+}
+
+func createControlPlane(registrationMethod, registrationAddress string) *controlplanev1.RKE2ControlPlane {
+	return &controlplanev1.RKE2ControlPlane{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: controlplanev1.RKE2ControlPlaneSpec{
+			RegistrationMethod:  controlplanev1.RegistrationMethod(registrationMethod),
+			RegistrationAddress: registrationAddress,
+		},
+		Status: controlplanev1.RKE2ControlPlaneStatus{},
+	}
+}
+
+func createMachine(name string, internalIPs []string, externalIPs []string) *clusterv1.Machine {
+	machine := &clusterv1.Machine{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Spec: clusterv1.MachineSpec{},
+		Status: clusterv1.MachineStatus{
+			Addresses: clusterv1.MachineAddresses{},
+		},
+	}
+
+	for _, internalIP := range internalIPs {
+		machine.Status.Addresses = append(machine.Status.Addresses, clusterv1.MachineAddress{
+			Type:    clusterv1.MachineInternalIP,
+			Address: internalIP,
+		})
+	}
+
+	for _, externalIP := range externalIPs {
+		machine.Status.Addresses = append(machine.Status.Addresses, clusterv1.MachineAddress{
+			Type:    clusterv1.MachineExternalIP,
+			Address: externalIP,
+		})
+	}
+
+	return machine
+}

--- a/pkg/rke2/control_plane.go
+++ b/pkg/rke2/control_plane.go
@@ -219,8 +219,8 @@ func (c *ControlPlane) GenerateRKE2Config(spec *bootstrapv1.RKE2ConfigSpec) *boo
 // ControlPlaneLabelsForCluster returns a set of labels to add to a control plane machine for this specific cluster.
 func ControlPlaneLabelsForCluster(clusterName string) map[string]string {
 	return map[string]string{
-		clusterv1.ClusterNameLabel:             clusterName,
-		clusterv1.MachineControlPlaneNameLabel: "",
+		clusterv1.ClusterNameLabel:         clusterName,
+		clusterv1.MachineControlPlaneLabel: "",
 	}
 }
 

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -178,7 +178,7 @@ func GetRKE2ControlPlaneByCluster(ctx context.Context, input GetRKE2ControlPlane
 	opts := []client.ListOption{
 		client.InNamespace(input.Namespace),
 		client.MatchingLabels{
-			clusterv1.ClusterLabelName: input.ClusterName,
+			clusterv1.ClusterNameLabel: input.ClusterName,
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds support for different ways to register new nodes into the cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #136
Fixes #146 


**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [x] includes documentation
- [x] adds unit tests
