### PR TITLE
fix: incorrectly defaulting advertise address

### DIFF
--- a/controlplane/api/v1alpha1/rke2controlplane_webhook.go
+++ b/controlplane/api/v1alpha1/rke2controlplane_webhook.go
@@ -47,16 +47,6 @@ var _ webhook.Defaulter = &RKE2ControlPlane{}
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
 func (r *RKE2ControlPlane) Default() {
 	bootstrapv1.DefaultRKE2ConfigSpec(&r.Spec.RKE2ConfigSpec)
-
-	if r.Spec.RegistrationMethod == RegistrationMethodAddress {
-		if r.Spec.ServerConfig.AdvertiseAddress == "" {
-			rke2controlplanelog.Info("setting advertise address from registration address",
-				"rke2-control-plane", klog.KObj(r),
-				"address", r.Spec.RegistrationAddress)
-
-			r.Spec.ServerConfig.AdvertiseAddress = r.Spec.RegistrationAddress
-		}
-	}
 }
 
 //+kubebuilder:webhook:path=/validate-controlplane-cluster-x-k8s-io-v1alpha1-rke2controlplane,mutating=false,failurePolicy=fail,sideEffects=None,groups=controlplane.cluster.x-k8s.io,resources=rke2controlplanes,verbs=create;update,versions=v1alpha1,name=vrke2controlplane.kb.io,admissionReviewVersions=v1

--- a/pkg/registration/registration_test.go
+++ b/pkg/registration/registration_test.go
@@ -117,8 +117,7 @@ func TestInternalFirstMethod(t *testing.T) {
 			actualAddresses, err := regMethod(tc.rcp, col)
 			g.Expect(err).NotTo(HaveOccurred())
 
-			g.Expect(actualAddresses).To(BeComparableTo(tc.expectedAddresses))
-
+			g.Expect(actualAddresses).To(HaveExactElements(tc.expectedAddresses))
 		})
 	}
 }
@@ -170,7 +169,7 @@ func TestInternalOnlyMethod(t *testing.T) {
 			actualAddresses, err := regMethod(tc.rcp, col)
 			g.Expect(err).NotTo(HaveOccurred())
 
-			g.Expect(actualAddresses).To(BeComparableTo(tc.expectedAddresses))
+			g.Expect(actualAddresses).To(HaveExactElements(tc.expectedAddresses))
 
 		})
 	}
@@ -223,7 +222,7 @@ func TestExternalOnlyMethod(t *testing.T) {
 			actualAddresses, err := regMethod(tc.rcp, col)
 			g.Expect(err).NotTo(HaveOccurred())
 
-			g.Expect(actualAddresses).To(BeComparableTo(tc.expectedAddresses))
+			g.Expect(actualAddresses).To(HaveExactElements(tc.expectedAddresses))
 
 		})
 	}
@@ -274,7 +273,7 @@ func TestAddressMethod(t *testing.T) {
 
 			expectedAddresses := []string{"100.100.100.100"}
 
-			g.Expect(actualAddresses).To(BeComparableTo(expectedAddresses))
+			g.Expect(actualAddresses).To(HaveExactElements(expectedAddresses))
 
 		})
 	}
@@ -321,4 +320,16 @@ func createMachine(name string, internalIPs []string, externalIPs []string) *clu
 	}
 
 	return machine
+}
+
+func strEquals(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/samples/docker/kube-vip/rke2-sample.yaml
+++ b/samples/docker/kube-vip/rke2-sample.yaml
@@ -1,0 +1,146 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${CABPR_NAMESPACE}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster 
+metadata:
+  namespace: ${CABPR_NAMESPACE}
+  name: ${CLUSTER_NAME} 
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - 10.45.0.0/16
+    services:
+      cidrBlocks:
+      - 10.46.0.0/16
+    serviceDomain: cluster.local
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+    kind: RKE2ControlPlane
+    name: ${CLUSTER_NAME}-control-plane
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: DockerCluster
+    name: ${CLUSTER_NAME}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerCluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${CABPR_NAMESPACE}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+kind: RKE2ControlPlane
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: ${CABPR_NAMESPACE}
+spec: 
+  replicas: ${CABPR_CP_REPLICAS}
+  agentConfig:
+    version: ${KUBERNETES_VERSION}+rke2r1
+  serverConfig:
+    cni: calico
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: DockerMachineTemplate
+    name: controlplane
+  nodeDrainTimeout: 2m
+  registrationMethod: "address"
+  registrationAddress: "${REGISTRATION_VIP}"
+  preRKE2Commands:
+  - mkdir -p /var/lib/rancher/rke2/server/manifests/ && ctr images pull ghcr.io/kube-vip/kube-vip:v0.6.0 && ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:v0.6.0 vip /kube-vip manifest daemonset --arp --interface $(ip -4 -j route list default | jq -r .[0].dev) --address ${REGISTRATION_VIP} --controlplane --leaderElection --taint --services --inCluster | tee /var/lib/rancher/rke2/server/manifests/kube-vip.yaml
+  files:
+  - path: /var/lib/rancher/rke2/server/manifests/kube-vip-rbac.yaml
+    content: |
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: kube-vip
+        namespace: kube-system
+      ---
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        annotations:
+          rbac.authorization.kubernetes.io/autoupdate: "true"
+        name: system:kube-vip-role
+      rules:
+        - apiGroups: [""]
+          resources: ["services", "services/status", "nodes", "endpoints"]
+          verbs: ["list","get","watch", "update"]
+        - apiGroups: ["coordination.k8s.io"]
+          resources: ["leases"]
+          verbs: ["list", "get", "watch", "update", "create"]
+      ---
+      kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: system:kube-vip-binding
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: system:kube-vip-role
+      subjects:
+      - kind: ServiceAccount
+        name: kube-vip
+        namespace: kube-system
+    owner: root:root
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerMachineTemplate
+metadata:
+  name: controlplane
+  namespace: ${CABPR_NAMESPACE}
+spec:
+  template:
+    spec: {} 
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: worker-md-0
+  namespace: ${CABPR_NAMESPACE}
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${CABPR_WK_REPLICAS}
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+  template:
+    spec:
+      version: ${KUBERNETES_VERSION}
+      clusterName: ${CLUSTER_NAME}
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
+          kind: RKE2ConfigTemplate
+          name: ${CLUSTER_NAME}-agent
+          namespace: ${CABPR_NAMESPACE}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: DockerMachineTemplate
+        name: worker
+        namespace: ${CABPR_NAMESPACE}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerMachineTemplate
+metadata:
+  name: worker
+  namespace: ${CABPR_NAMESPACE}
+spec:
+  template:
+    spec: {} 
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
+kind: RKE2ConfigTemplate
+metadata:
+  namespace: ${CABPR_NAMESPACE}
+  name: ${CLUSTER_NAME}-agent
+spec: 
+  template:
+    spec:
+      agentConfig:
+        version: ${KUBERNETES_VERSION}+rke2r1


### PR DESCRIPTION
**What this PR does / why we need it**:

With the recent change to introduce new registration methods we started to default the `advertiseAddress` to the "registration address" if the registration method of `address` was used. This caused the kube-api server to be startedw tith that address. If you then used a VIP/LB solution like kube-vip or metalb that runs within cluster it caused pods to not start start as there is a chicken and egg scenario.

This change removes that defaulting and also adds a sample that uses kube-vip.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
