### PR TITLE
Fix manifest URLs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,17 +65,17 @@ In order to use `clusterctl` to deploy the RKE2 Provider, you need a specific co
 ```yaml
 providers:
   - name: "rke2"
-    url: "https://github.com/rancher-sandbox/cluster-api-provider-rke2/releases/v0.1.1/bootstrap-components.yaml"
+    url: "https://github.com/rancher-sandbox/cluster-api-provider-rke2/releases/download/v0.1.1/bootstrap-components.yaml"
     type: "BootstrapProvider"
   - name: "rke2"
-    url: "https://github.com/rancher-sandbox/cluster-api-provider-rke2/releases/v0.1.1/control-plane-components.yaml"
+    url: "https://github.com/rancher-sandbox/cluster-api-provider-rke2/releases/download/v0.1.1/control-plane-components.yaml"
     type: "ControlPlaneProvider"
 ``` 
 > NOTE: Due to some issue related to how `CAPD` creates Load Balancer healthchecks, it is necessary to use a fork of `CAPD` by providing in the above configuration file the following :
 
 ```yaml
   - name: "docker"
-    url: "https://github.com/belgaied2/cluster-api/releases/v1.3.3-cabpr-fix/infrastructure-components.yaml"
+    url: "https://github.com/belgaied2/cluster-api/releases/download/v1.3.3-cabpr-fix/infrastructure-components.yaml"
     type: "InfrastructureProvider"
 ``` 
 


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

kind/documentation

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

The original URLs were broken.

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [x] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
