### PR TITLE
Re-enable ability to choose to disable cloud controller

### DIFF
--- a/pkg/rke2/config.go
+++ b/pkg/rke2/config.go
@@ -244,10 +244,11 @@ func newRKE2ServerConfig(opts ServerConfigOpts) (*rke2ServerConfig, []bootstrapv
 			rke2ServerConfig.DisableKubeProxy = true
 		case controlplanev1.Scheduler:
 			rke2ServerConfig.DisableScheduler = true
+		case controlplanev1.CloudController:
+			rke2ServerConfig.DisableCloudController = true
 		}
 	}
 
-	rke2ServerConfig.DisableCloudController = true
 	rke2ServerConfig.EtcdDisableSnapshots = opts.ServerConfig.Etcd.BackupConfig.DisableAutomaticSnapshots
 	rke2ServerConfig.EtcdExposeMetrics = opts.ServerConfig.Etcd.ExposeMetrics
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This reverts a previous change so that a user can choose whether to disable ttheeh cloud controller or not

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #197 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes

