### PR TITLE
docs: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,24 +205,24 @@ These instructions are for development purposes initially and will be changed in
 > **Why clone into the GOPATH?** There have been historic issues with code generation tools when they are run outside the go path
 
 2. Fork the [Cluster API Provider RKE2](https://github.com/rancher-sandbox/cluster-api-provider-rke2) repo
-3. Clone your new repo into the **GOPATH** (i.e. `~/go/src/github.com/myname/cluster-api-provider-rke2`)
+3. Clone your new repo into the **GOPATH** (i.e. `~/go/src/github.com/yourname/cluster-api-provider-rke2`)
 4. Ensure **Tilt** and **kind** are installed
 5. Create a `tilt-settings.json` file in the root of your forked/cloned `cluster-api` directory.
 6. Add the following contents to the file (replace "yourname" with your github account name):
 
 ```json
 {
-    "default_registry": "ghcr.io/rancher-sandox",
-    "provider_repos": ["../../github.com/rancher-sandbox/cluster-api-provider-rke2"],
+    "default_registry": "ghcr.io/yourname",
+    "provider_repos": ["../../github.com/yourname/cluster-api-provider-rke2"],
     "enable_providers": ["docker", "rke2-bootstrap", "rke2-control-plane"],
     "kustomize_substitutions": {
         "EXP_MACHINE_POOL": "true",
         "EXP_CLUSTER_RESOURCE_SET": "true"
     },
     "extra_args": {
-        "rke2-bootstrap": ["-zap-log-level=debug"],
-        "rke2-control-plane": ["-zap-log-level=debug"],
-        "core": ["-zap-log-level=debug"]
+        "rke2-bootstrap": ["--v=4"],
+        "rke2-control-plane": ["--v=4"],
+        "core": ["--v=4"]
     },
     "debug": {
         "rke2-bootstrap": {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds minor changes to README:
- The `tilt-settings.json` template used to create a development environment uses `extra_args` for setting logging level that seem to be deprecated and cause errors: `-zap-log-level=debug` is changed to `--v=4`.
- Use placeholder `yourname` in registry URLs as stated in https://github.com/salasberryfin/cluster-api-provider-rke2/blob/5489252774b98a0457ca93bdfda0df4f5d7188f6/README.md?plain=1#L211.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [x] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
