### PR TITLE
:bug: Ensure we always lookup machines by node name from collection

### DIFF
--- a/pkg/rke2/control_plane.go
+++ b/pkg/rke2/control_plane.go
@@ -76,13 +76,17 @@ func NewControlPlane(
 
 	patchHelpers := map[string]*patch.Helper{}
 
-	for _, machine := range ownedMachines {
+	for name, machine := range ownedMachines {
 		patchHelper, err := patch.NewHelper(machine, client)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to create patch helper for machine %s", machine.Name)
+			if machine.Status.NodeRef != nil {
+				name = machine.Status.NodeRef.Name
+			}
+
+			return nil, errors.Wrapf(err, "failed to create patch helper for machine %s with node %s", machine.Name, name)
 		}
 
-		patchHelpers[machine.Name] = patchHelper
+		patchHelpers[name] = patchHelper
 	}
 
 	return &ControlPlane{
@@ -305,7 +309,7 @@ func getInfraResources(ctx context.Context, cl client.Client, machines collectio
 func getRKE2Configs(ctx context.Context, cl client.Client, machines collections.Machines) (map[string]*bootstrapv1.RKE2Config, error) {
 	result := map[string]*bootstrapv1.RKE2Config{}
 
-	for _, m := range machines {
+	for name, m := range machines {
 		bootstrapRef := m.Spec.Bootstrap.ConfigRef
 		if bootstrapRef == nil {
 			continue
@@ -318,10 +322,14 @@ func getRKE2Configs(ctx context.Context, cl client.Client, machines collections.
 				continue
 			}
 
-			return nil, errors.Wrapf(err, "failed to retrieve bootstrap config for machine %q", m.Name)
+			if m.Status.NodeRef != nil {
+				name = m.Status.NodeRef.Name
+			}
+
+			return nil, errors.Wrapf(err, "failed to retrieve bootstrap config for machine %q with node %s", m.Name, name)
 		}
 
-		result[m.Name] = machineConfig
+		result[name] = machineConfig
 	}
 
 	return result, nil
@@ -346,21 +354,29 @@ func (c *ControlPlane) HasUnhealthyMachine() bool {
 func (c *ControlPlane) PatchMachines(ctx context.Context) error {
 	errList := []error{}
 
-	for i := range c.Machines {
-		machine := c.Machines[i]
-		if helper, ok := c.machinesPatchHelpers[machine.Name]; ok {
+	for name := range c.Machines {
+		machine := c.Machines[name]
+		if helper, ok := c.machinesPatchHelpers[name]; ok {
 			if err := helper.Patch(ctx, machine, patch.WithOwnedConditions{Conditions: []clusterv1.ConditionType{
 				controlplanev1.MachineAgentHealthyCondition,
 				controlplanev1.MachineEtcdMemberHealthyCondition,
 				controlplanev1.NodeMetadataUpToDate,
 			}}); err != nil {
-				errList = append(errList, errors.Wrapf(err, "failed to patch machine %s", machine.Name))
+				if machine.Status.NodeRef != nil {
+					name = machine.Status.NodeRef.Name
+				}
+
+				errList = append(errList, errors.Wrapf(err, "failed to patch machine %s with node %s", machine.Name, name))
 			}
 
 			continue
 		}
 
-		errList = append(errList, errors.Errorf("failed to get patch helper for machine %s", machine.Name))
+		if machine.Status.NodeRef != nil {
+			name = machine.Status.NodeRef.Name
+		}
+
+		errList = append(errList, errors.Errorf("failed to get patch helper for machine %s with node %s", machine.Name, name))
 	}
 
 	return kerrors.NewAggregate(errList)

--- a/pkg/rke2/workload_cluster.go
+++ b/pkg/rke2/workload_cluster.go
@@ -168,12 +168,6 @@ func (w *Workload) PatchNodes(ctx context.Context, cp *ControlPlane) error {
 				errList = append(errList, errors.Wrapf(err, "failed to patch node %s", node.Name))
 			}
 
-			if !conditions.Has(machine, controlplanev1.NodeMetadataUpToDate) {
-				conditions.MarkTrue(
-					machine,
-					controlplanev1.NodeMetadataUpToDate)
-			}
-
 			continue
 		}
 
@@ -481,6 +475,8 @@ func (w *Workload) UpdateNodeMetadata(ctx context.Context, controlPlane *Control
 		if machine.Status.NodeRef != nil {
 			nodeName = machine.Status.NodeRef.Name
 		}
+
+		conditions.MarkTrue(machine, controlplanev1.NodeMetadataUpToDate)
 
 		node, nodeFound := w.Nodes[nodeName]
 		if !nodeFound {

--- a/pkg/rke2/workload_cluster_test.go
+++ b/pkg/rke2/workload_cluster_test.go
@@ -120,8 +120,8 @@ var _ = Describe("Node metadata propagation", func() {
 
 		w := NewWorkload(testEnv.GetClient())
 		cp, err := NewControlPlane(ctx, testEnv.GetClient(), nil, nil, machines)
-		w.InitWorkload(ctx, cp)
 		Expect(err).ToNot(HaveOccurred())
+		Expect(w.InitWorkload(ctx, cp)).ToNot(HaveOccurred())
 		Expect(w.UpdateNodeMetadata(ctx, cp)).ToNot(HaveOccurred())
 		Expect(w.Nodes).To(HaveLen(0))
 		Expect(cp.rke2Configs).To(HaveLen(1))
@@ -144,8 +144,8 @@ var _ = Describe("Node metadata propagation", func() {
 
 		w := NewWorkload(testEnv.GetClient())
 		cp, err := NewControlPlane(ctx, testEnv.GetClient(), nil, nil, machines)
-		w.InitWorkload(ctx, cp)
 		Expect(err).ToNot(HaveOccurred())
+		Expect(w.InitWorkload(ctx, cp)).ToNot(HaveOccurred())
 		Expect(w.UpdateNodeMetadata(ctx, cp)).ToNot(HaveOccurred())
 		Expect(w.Nodes).To(HaveLen(1))
 		Expect(cp.rke2Configs).To(HaveLen(0))
@@ -156,6 +156,46 @@ var _ = Describe("Node metadata propagation", func() {
 		Expect(conditions.Get(cp.Machines[machine.Name], controlplanev1.NodeMetadataUpToDate)).To(HaveField(
 			"Message", Equal("associated RKE2 config not found"),
 		))
+	})
+
+	It("should recover from error conditions on successfull node patch", func() {
+		Expect(testEnv.Create(ctx, config)).To(Succeed())
+		Expect(testEnv.Create(ctx, machine)).To(Succeed())
+
+		machines := collections.FromMachineList(&clusterv1.MachineList{Items: []clusterv1.Machine{
+			*machine,
+		}})
+
+		w := NewWorkload(testEnv.GetClient())
+		cp, err := NewControlPlane(ctx, testEnv.GetClient(), nil, nil, machines)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(w.InitWorkload(ctx, cp)).ToNot(HaveOccurred())
+		Expect(w.UpdateNodeMetadata(ctx, cp)).ToNot(HaveOccurred())
+		Expect(w.Nodes).To(HaveLen(0))
+		Expect(cp.rke2Configs).To(HaveLen(1))
+		Expect(cp.Machines).To(HaveLen(1))
+		Expect(conditions.Get(cp.Machines[machine.Name], controlplanev1.NodeMetadataUpToDate)).To(HaveField(
+			"Status", Equal(corev1.ConditionUnknown),
+		))
+		Expect(conditions.Get(cp.Machines[machine.Name], controlplanev1.NodeMetadataUpToDate)).To(HaveField(
+			"Message", Equal("associated node not found"),
+		))
+
+		Expect(testEnv.Create(ctx, node)).To(Succeed())
+		Eventually(ctx, func() map[string]*corev1.Node {
+			Expect(w.InitWorkload(ctx, cp)).ToNot(HaveOccurred())
+			return w.Nodes
+		}).Should(HaveLen(1))
+		Expect(w.UpdateNodeMetadata(ctx, cp)).ToNot(HaveOccurred())
+		Expect(cp.rke2Configs).To(HaveLen(1))
+		Expect(cp.Machines).To(HaveLen(1))
+		Expect(conditions.Get(cp.Machines[machine.Name], controlplanev1.NodeMetadataUpToDate)).To(HaveField(
+			"Status", Equal(corev1.ConditionTrue),
+		))
+		Expect(w.Nodes[nodeName].GetAnnotations()).To(Equal(map[string]string{
+			"test":                      "true",
+			clusterv1.MachineAnnotation: nodeName,
+		}))
 	})
 
 	It("should set the node annotations", func() {
@@ -169,7 +209,7 @@ var _ = Describe("Node metadata propagation", func() {
 
 		w := NewWorkload(testEnv.GetClient())
 		cp, err := NewControlPlane(ctx, testEnv.GetClient(), nil, nil, machines)
-		w.InitWorkload(ctx, cp)
+		Expect(w.InitWorkload(ctx, cp)).ToNot(HaveOccurred())
 		Expect(err).ToNot(HaveOccurred())
 		Expect(w.UpdateNodeMetadata(ctx, cp)).ToNot(HaveOccurred())
 		Expect(w.Nodes).To(HaveLen(1))
@@ -207,8 +247,8 @@ var _ = Describe("Node metadata propagation", func() {
 
 		w := NewWorkload(testEnv.GetClient())
 		cp, err := NewControlPlane(ctx, testEnv.GetClient(), nil, nil, machines)
-		w.InitWorkload(ctx, cp)
 		Expect(err).ToNot(HaveOccurred())
+		Expect(w.InitWorkload(ctx, cp)).ToNot(HaveOccurred())
 		Expect(w.UpdateNodeMetadata(ctx, cp)).ToNot(HaveOccurred())
 		Expect(w.Nodes).To(HaveLen(1))
 		Expect(cp.rke2Configs).To(HaveLen(1))
@@ -228,6 +268,61 @@ var _ = Describe("Node metadata propagation", func() {
 			clusterv1.MachineAnnotation: machineDifferentNode.Name,
 		}))
 	})
+
+	It("should recover from error condition on successfull node patch for arbitrary node name", func() {
+		node.SetAnnotations(map[string]string{
+			clusterv1.MachineAnnotation: machineDifferentNode.Name,
+		})
+		Expect(testEnv.Create(ctx, node)).To(Succeed())
+		Expect(testEnv.Create(ctx, config)).To(Succeed())
+		Expect(testEnv.Create(ctx, machineDifferentNode)).To(Succeed())
+
+		machines := collections.FromMachineList(&clusterv1.MachineList{Items: []clusterv1.Machine{
+			*machineDifferentNode,
+		}})
+
+		w := NewWorkload(testEnv.GetClient())
+		cp, err := NewControlPlane(ctx, testEnv.GetClient(), nil, nil, machines)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(w.InitWorkload(ctx, cp)).ToNot(HaveOccurred())
+		Expect(w.UpdateNodeMetadata(ctx, cp)).ToNot(HaveOccurred())
+		Expect(w.Nodes).To(HaveLen(1))
+		Expect(cp.rke2Configs).To(HaveLen(1))
+		Expect(cp.Machines).To(HaveLen(1))
+		Expect(conditions.Get(cp.Machines[machineDifferentNode.Name], controlplanev1.NodeMetadataUpToDate)).To(HaveField(
+			"Status", Equal(corev1.ConditionUnknown),
+		))
+		Expect(conditions.Get(cp.Machines[machineDifferentNode.Name], controlplanev1.NodeMetadataUpToDate)).To(HaveField(
+			"Message", Equal("associated node not found"),
+		))
+
+		machineDifferentNode.Status = machineNodeRefStatus
+		Expect(testEnv.Status().Update(ctx, machineDifferentNode)).To(Succeed())
+
+		machines = collections.FromMachineList(&clusterv1.MachineList{Items: []clusterv1.Machine{
+			*machineDifferentNode,
+		}})
+		cp, err = NewControlPlane(ctx, testEnv.GetClient(), nil, nil, machines)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(w.InitWorkload(ctx, cp)).ToNot(HaveOccurred())
+		Expect(w.UpdateNodeMetadata(ctx, cp)).ToNot(HaveOccurred())
+
+		Expect(conditions.Get(cp.Machines[machineDifferentNode.Name], controlplanev1.NodeMetadataUpToDate)).To(HaveField(
+			"Status", Equal(corev1.ConditionTrue),
+		))
+		Expect(w.Nodes[nodeName].GetAnnotations()).To(Equal(map[string]string{
+			"test":                      "true",
+			clusterv1.MachineAnnotation: machineDifferentNode.Name,
+		}))
+
+		result := &corev1.Node{}
+		Expect(testEnv.Get(ctx, client.ObjectKeyFromObject(node), result)).To(Succeed())
+		Expect(result.GetAnnotations()).To(Equal(map[string]string{
+			"test":                      "true",
+			clusterv1.MachineAnnotation: machineDifferentNode.Name,
+		}))
+	})
+
 })
 
 var _ = Describe("Cloud-init fields validation", func() {


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
It seems that in some child clusters provisioned node names are different from machine names, causing control plane to loose node reference. This fix ensures that all machine collections refer to an actual nodeName reference if one is found upon provisioning.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #257
Fixes #224

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
