### PR TITLE
feat: added control plane endpoint registration method

### DIFF
--- a/controlplane/api/v1beta1/rke2controlplane_types.go
+++ b/controlplane/api/v1beta1/rke2controlplane_types.go
@@ -78,7 +78,7 @@ type RKE2ControlPlaneSpec struct {
 	NodeDrainTimeout *metav1.Duration `json:"nodeDrainTimeout,omitempty"`
 
 	// RegistrationMethod is the method to use for registering nodes into the RKE2 cluster.
-	// +kubebuilder:validation:Enum=internal-first;internal-only-ips;external-only-ips;address
+	// +kubebuilder:validation:Enum=internal-first;internal-only-ips;external-only-ips;address;control-plane-endpoint
 	// +kubebuilder:default=internal-first
 	// +optional
 	RegistrationMethod RegistrationMethod `json:"registrationMethod"`

--- a/controlplane/api/v1beta1/types.go
+++ b/controlplane/api/v1beta1/types.go
@@ -33,4 +33,7 @@ var (
 	// RegistrationMethodAddress is a registration method where an explicit address supplied at cluster creation
 	// time is used for registration. This is for use in LB or VIP scenarios.
 	RegistrationMethodAddress = RegistrationMethod("address")
+	// RegistrationMethodControlPlaneEndpoint is a registration method where the control plane endpoint from the
+	// Cluster is used for registration.
+	RegistrationMethodControlPlaneEndpoint = RegistrationMethod("control-plane-endpoint")
 )

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanes.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanes.yaml
@@ -1854,6 +1854,7 @@ spec:
                 - internal-only-ips
                 - external-only-ips
                 - address
+                - control-plane-endpoint
                 type: string
               replicas:
                 description: Replicas is the number of replicas for the Control Plane.

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanetemplates.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanetemplates.yaml
@@ -763,6 +763,7 @@ spec:
                         - internal-only-ips
                         - external-only-ips
                         - address
+                        - control-plane-endpoint
                         type: string
                       replicas:
                         description: Replicas is the number of replicas for the Control

--- a/controlplane/internal/controllers/rke2controlplane_controller.go
+++ b/controlplane/internal/controllers/rke2controlplane_controller.go
@@ -359,7 +359,7 @@ func (r *RKE2ControlPlaneReconciler) updateStatus(ctx context.Context, rcp *cont
 		return fmt.Errorf("getting node registration method: %w", err)
 	}
 
-	validIPAddresses, err := registrationmethod(rcp, availableCPMachines)
+	validIPAddresses, err := registrationmethod(cluster, rcp, availableCPMachines)
 	if err != nil {
 		return fmt.Errorf("getting registration addresses: %w", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds a new registration method that will use the **host** from the control plane endpoint set on the **Cluster**. This is aimed at users that will use an external LB in front of the control-plane machines.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
