### PR TITLE
:seedling: Enable e2e as a pre-submit job

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,5 +1,6 @@
 name: E2E tests
 on:
+  pull_request:
   schedule:
     - cron: '0 1 * * *'
   workflow_dispatch:


### PR DESCRIPTION
Enabling e2e workflow as a pre-submit job, now that the e2e nightly tests are passing.

<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
