### PR TITLE
Let the rke2-install.sh fail for pipe errors and undefined variables

### DIFF
--- a/bootstrap/internal/ignition/butane/butane.go
+++ b/bootstrap/internal/ignition/butane/butane.go
@@ -108,7 +108,7 @@ storage:
       contents:
         inline: |
           #!/bin/bash
-          set -e
+          set -euo pipefail
           {{ range .PreRKE2Commands }}
           {{ . | Indent 10 }}
           {{- end }}


### PR DESCRIPTION
The rke2-install.sh script sets the exit on error flag ('set -e'), however the script might fail to exit when a command in a pipe fails. Add the '-u' and '-o pipefail' flags to better identify errors within the install script.

Fixes #276