### PR TITLE
Check rke2-serving secret to determine controlPlane.Status.Initialized

### DIFF
--- a/pkg/rke2/workload_cluster.go
+++ b/pkg/rke2/workload_cluster.go
@@ -276,8 +276,12 @@ func (w *Workload) ClusterStatus(ctx context.Context) ClusterStatus {
 		Namespace: metav1.NamespaceSystem,
 	}
 	err := w.Client.Get(ctx, key, &corev1.Secret{})
-
 	// In case of error we do assume the control plane is not initialized yet.
+	if err != nil {
+		logger := log.FromContext(ctx)
+		logger.Info("Control Plane does not seem to be initialized yet.", "reason", err.Error())
+	}
+
 	status.HasRKE2ServingSecret = err == nil
 
 	return status


### PR DESCRIPTION
kind/bug

**What this PR does / why we need it**:

This should fix the behavior around setting the `controlPlane.Status.Initialized` flag. 
As per [documentation](https://cluster-api.sigs.k8s.io/developer/architecture/controllers/control-plane#required-status-fields), this flag is:
```text
a boolean field that is true when the target cluster has completed initialization such that at least once, the target's control plane has been contactable.
```

The implementation is in line with Kubeadm, but instead of checking if the `kubeadm-config` ConfigMap was uploaded on the cluster, we check if the `rke2-serving` secret was.
This should be equivalent and as well a good enough marker that the control plane was indeed initialized.

**Which issue(s) this PR fixes**:
This should fix the RKE2 control plane provider deadlocking when disabling the `cloudController` kubernetes component.

```yaml
  serverConfig:
    disableComponents:
      kubernetesComponents:
        - cloudController
```

Disabling this component will forbid RKE2 from applying the `node.Spec.ProviderID` automatically. CAPI Infrastructure providers should manage that instead, but by contract they need the `ControlPlaneInitialized` condition to be true before attempting. This is the cause of the deadlock.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
