### PR TITLE
Use spec.Version field as primarily source

### DIFF
--- a/bootstrap/api/v1beta1/rke2config_types.go
+++ b/bootstrap/api/v1beta1/rke2config_types.go
@@ -148,6 +148,7 @@ type RKE2AgentConfig struct {
 
 	// Version specifies the rke2 version.
 	// This field will be deprecated in newer versions of the API and RKE2ControlPlaneSpec.Version will be used instead.
+	// +kubebuilder:validation:Pattern="v(\\d\\.\\d{2}\\.\\d)\\+rke2r\\d"
 	//+optional
 	Version string `json:"version,omitempty"`
 

--- a/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_rke2configs.yaml
+++ b/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_rke2configs.yaml
@@ -892,6 +892,7 @@ spec:
                     description: |-
                       Version specifies the rke2 version.
                       This field will be deprecated in newer versions of the API and RKE2ControlPlaneSpec.Version will be used instead.
+                    pattern: v(\d\.\d{2}\.\d)\+rke2r\d
                     type: string
                 type: object
               files:

--- a/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_rke2configtemplates.yaml
+++ b/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_rke2configtemplates.yaml
@@ -875,6 +875,7 @@ spec:
                             description: |-
                               Version specifies the rke2 version.
                               This field will be deprecated in newer versions of the API and RKE2ControlPlaneSpec.Version will be used instead.
+                            pattern: v(\d\.\d{2}\.\d)\+rke2r\d
                             type: string
                         type: object
                       files:

--- a/controlplane/api/v1beta1/rke2controlplane_types.go
+++ b/controlplane/api/v1beta1/rke2controlplane_types.go
@@ -47,9 +47,8 @@ type RKE2ControlPlaneSpec struct {
 	Replicas *int32 `json:"replicas,omitempty"`
 
 	// Version defines the desired Kubernetes version.
-	// This is only a placeholder for now, and the RKE2ConfigSpec.AgentConfig.Version field should be used instead.
-	// In future iterations, this field overrides the RKE2 Version specificied in RKE2ConfigSpec.AgentConfig.Version
-	// which will be deprecated in newer versions of the API.
+	// This field takes precedence over RKE2ConfigSpec.AgentConfig.Version (which is deprecated).
+	// +kubebuilder:validation:Pattern="v(\\d\\.\\d{2}\\.\\d)\\+rke2r\\d"
 	// +optional
 	Version string `json:"version"`
 
@@ -435,4 +434,13 @@ func (r *RKE2ControlPlane) GetConditions() clusterv1.Conditions {
 // SetConditions sets the list of conditions for a RKE2ControlPlane object.
 func (r *RKE2ControlPlane) SetConditions(conditions clusterv1.Conditions) {
 	r.Status.Conditions = conditions
+}
+
+// GetDesiredVersion returns the desired version of the RKE2ControlPlane using Spec.Version field as a default field.
+func (r *RKE2ControlPlane) GetDesiredVersion() string {
+	if r.Spec.Version != "" {
+		return r.Spec.Version
+	}
+
+	return r.Spec.AgentConfig.Version
 }

--- a/controlplane/api/v1beta1/rke2controlplane_types.go
+++ b/controlplane/api/v1beta1/rke2controlplane_types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1beta1
 
 import (
+	"regexp"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -438,9 +440,18 @@ func (r *RKE2ControlPlane) SetConditions(conditions clusterv1.Conditions) {
 
 // GetDesiredVersion returns the desired version of the RKE2ControlPlane using Spec.Version field as a default field.
 func (r *RKE2ControlPlane) GetDesiredVersion() string {
-	if r.Spec.Version != "" {
+	if r.Spec.Version != "" && isRKE2Version(r.Spec.Version) {
 		return r.Spec.Version
 	}
 
 	return r.Spec.AgentConfig.Version
+}
+
+// isRKE2Version checks if a string is an RKE2 version.
+func isRKE2Version(rke2Version string) bool {
+	regexStr := "v(\\d\\.\\d{2}\\.\\d)\\+rke2r\\d"
+
+	regex, _ := regexp.Compile(regexStr)
+
+	return regex.MatchString(rke2Version)
 }

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanes.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanes.yaml
@@ -1537,6 +1537,7 @@ spec:
                     description: |-
                       Version specifies the rke2 version.
                       This field will be deprecated in newer versions of the API and RKE2ControlPlaneSpec.Version will be used instead.
+                    pattern: v(\d\.\d{2}\.\d)\+rke2r\d
                     type: string
                 type: object
               files:
@@ -2449,9 +2450,8 @@ spec:
               version:
                 description: |-
                   Version defines the desired Kubernetes version.
-                  This is only a placeholder for now, and the RKE2ConfigSpec.AgentConfig.Version field should be used instead.
-                  In future iterations, this field overrides the RKE2 Version specificied in RKE2ConfigSpec.AgentConfig.Version
-                  which will be deprecated in newer versions of the API.
+                  This field takes precedence over RKE2ConfigSpec.AgentConfig.Version (which is deprecated).
+                pattern: v(\d\.\d{2}\.\d)\+rke2r\d
                 type: string
             required:
             - infrastructureRef

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanetemplates.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanetemplates.yaml
@@ -368,6 +368,7 @@ spec:
                             description: |-
                               Version specifies the rke2 version.
                               This field will be deprecated in newer versions of the API and RKE2ControlPlaneSpec.Version will be used instead.
+                            pattern: v(\d\.\d{2}\.\d)\+rke2r\d
                             type: string
                         type: object
                       files:
@@ -1300,9 +1301,8 @@ spec:
                       version:
                         description: |-
                           Version defines the desired Kubernetes version.
-                          This is only a placeholder for now, and the RKE2ConfigSpec.AgentConfig.Version field should be used instead.
-                          In future iterations, this field overrides the RKE2 Version specificied in RKE2ConfigSpec.AgentConfig.Version
-                          which will be deprecated in newer versions of the API.
+                          This field takes precedence over RKE2ConfigSpec.AgentConfig.Version (which is deprecated).
+                        pattern: v(\d\.\d{2}\.\d)\+rke2r\d
                         type: string
                     required:
                     - infrastructureRef

--- a/controlplane/internal/controllers/rke2controlplane_controller.go
+++ b/controlplane/internal/controllers/rke2controlplane_controller.go
@@ -609,9 +609,9 @@ func (r *RKE2ControlPlaneReconciler) reconcileEtcdMembers(ctx context.Context, c
 		return errors.Wrap(err, "cannot get remote client to workload cluster")
 	}
 
-	parsedVersion, err := semver.ParseTolerant(controlPlane.RCP.Spec.AgentConfig.Version)
+	parsedVersion, err := semver.ParseTolerant(controlPlane.RCP.GetDesiredVersion())
 	if err != nil {
-		return errors.Wrapf(err, "failed to parse kubernetes version %q", controlPlane.RCP.Spec.AgentConfig.Version)
+		return errors.Wrapf(err, "failed to parse kubernetes version %q", controlPlane.RCP.GetDesiredVersion())
 	}
 
 	removedMembers, err := workloadCluster.ReconcileEtcdMembers(ctx, nodeNames, parsedVersion)

--- a/controlplane/internal/controllers/scale.go
+++ b/controlplane/internal/controllers/scale.go
@@ -19,7 +19,6 @@ package controllers
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"time"
 
@@ -42,7 +41,6 @@ import (
 	bootstrapv1 "github.com/rancher-sandbox/cluster-api-provider-rke2/bootstrap/api/v1beta1"
 	controlplanev1 "github.com/rancher-sandbox/cluster-api-provider-rke2/controlplane/api/v1beta1"
 	rke2 "github.com/rancher-sandbox/cluster-api-provider-rke2/pkg/rke2"
-	bsutil "github.com/rancher-sandbox/cluster-api-provider-rke2/pkg/util"
 )
 
 func (r *RKE2ControlPlaneReconciler) initializeControlPlane(
@@ -413,14 +411,11 @@ func (r *RKE2ControlPlaneReconciler) generateMachine(
 	bootstrapRef *corev1.ObjectReference,
 	failureDomain *string,
 ) error {
-	newVersion, err := bsutil.Rke2ToKubeVersion(rcp.Spec.AgentConfig.Version)
-	if err != nil {
-		return fmt.Errorf("failed to convert rke2 version to kubernetes version: %w", err)
-	}
-
 	logger := log.FromContext(ctx)
 
-	logger.Info("Version checking...", "rke2-version", rcp.Spec.AgentConfig.Version, "machine-version: ", newVersion)
+	rke2Version := rcp.GetDesiredVersion()
+
+	logger.Info("Version checking...", "rke2-version", rke2Version)
 
 	machine := &clusterv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
@@ -433,7 +428,7 @@ func (r *RKE2ControlPlaneReconciler) generateMachine(
 		},
 		Spec: clusterv1.MachineSpec{
 			ClusterName:       cluster.Name,
-			Version:           &newVersion,
+			Version:           &rke2Version,
 			InfrastructureRef: *infraRef,
 			Bootstrap: clusterv1.Bootstrap{
 				ConfigRef: bootstrapRef,

--- a/pkg/rke2/config.go
+++ b/pkg/rke2/config.go
@@ -155,6 +155,7 @@ type ServerConfigOpts struct {
 	AgentConfig          bootstrapv1.RKE2AgentConfig
 	Ctx                  context.Context
 	Client               client.Client
+	Version              string
 }
 
 func newRKE2ServerConfig(opts ServerConfigOpts) (*rke2ServerConfig, []bootstrapv1.File, error) { // nolint:gocyclo
@@ -403,6 +404,7 @@ type AgentConfigOpts struct {
 	Client                 client.Client
 	CloudProviderName      string
 	CloudProviderConfigMap *corev1.ObjectReference
+	Version                string
 }
 
 func newRKE2AgentConfig(opts AgentConfigOpts) (*rke2AgentConfig, []bootstrapv1.File, error) {
@@ -411,8 +413,8 @@ func newRKE2AgentConfig(opts AgentConfigOpts) (*rke2AgentConfig, []bootstrapv1.F
 	rke2AgentConfig.ContainerRuntimeEndpoint = opts.AgentConfig.ContainerRuntimeEndpoint
 
 	if opts.AgentConfig.CISProfile != "" {
-		if !bsutil.ProfileCompliant(opts.AgentConfig.CISProfile, opts.AgentConfig.Version) {
-			return nil, nil, fmt.Errorf("profile %q is not supported for version %q", opts.AgentConfig.CISProfile, opts.AgentConfig.Version)
+		if !bsutil.ProfileCompliant(opts.AgentConfig.CISProfile, opts.Version) {
+			return nil, nil, fmt.Errorf("profile %q is not supported for version %q", opts.AgentConfig.CISProfile, opts.Version)
 		}
 
 		files = append(files, bootstrapv1.File{
@@ -550,6 +552,7 @@ func GenerateInitControlPlaneConfig(opts ServerConfigOpts) (*rke2ServerConfig, [
 		Client:      opts.Client,
 		Ctx:         opts.Ctx,
 		Token:       opts.Token,
+		Version:     opts.Version,
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to generate rke2 agent config: %w", err)
@@ -581,6 +584,7 @@ func GenerateJoinControlPlaneConfig(opts ServerConfigOpts) (*rke2ServerConfig, [
 		Ctx:         opts.Ctx,
 		ServerURL:   opts.ServerURL,
 		Token:       opts.Token,
+		Version:     opts.Version,
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to generate rke2 agent config: %w", err)

--- a/pkg/rke2/config_test.go
+++ b/pkg/rke2/config_test.go
@@ -295,8 +295,8 @@ var _ = Describe("RKE2 Agent Config", func() {
 					ExtraEnv:      map[string]string{"testenv": "testenv"},
 					ExtraMounts:   map[string]string{"testmount": "testmount"},
 				},
-				Version: "v1.25.2",
 			},
+			Version: "v1.25.2",
 		}
 	})
 

--- a/pkg/rke2/control_plane.go
+++ b/pkg/rke2/control_plane.go
@@ -116,7 +116,9 @@ func (c *ControlPlane) FailureDomains() clusterv1.FailureDomains {
 
 // Version returns the RKE2ControlPlane's version.
 func (c *ControlPlane) Version() *string {
-	return &c.RCP.Spec.AgentConfig.Version
+	version := c.RCP.GetDesiredVersion()
+
+	return &version
 }
 
 // InfrastructureRef returns the RKE2ControlPlane's infrastructure template.

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -128,6 +128,15 @@ func Rke2ToKubeVersion(rk2Version string) (kubeVersion string, err error) {
 	return kubeVersion, nil
 }
 
+// IsRKE2Version checks if a string is an RKE2 version.
+func IsRKE2Version(rke2Version string) bool {
+	regexStr := "v(\\d\\.\\d{2}\\.\\d)\\+rke2r\\d"
+
+	regex, _ := regexp.Compile(regexStr)
+
+	return regex.MatchString(rke2Version)
+}
+
 // AppendIfNotPresent appends a string to a slice only if the value does not already exist.
 func AppendIfNotPresent(origSlice []string, strItem string) (resultSlice []string) {
 	present := false

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -26,3 +26,16 @@ var _ = Describe(("Testing GetMapKeysAsString"), func() {
 		Expect(keysValid).To(BeTrue())
 	})
 })
+
+var _ = Describe("Testing IsRKE2Version", func() {
+	k8sVersion := "1.24.6"
+	rke2Version := "v1.24.6+rke2r1"
+
+	It("Should return true if string is RKE2 version", func() {
+		Expect(IsRKE2Version(rke2Version)).To(BeTrue())
+	})
+
+	It("Should return false if string is not RKE2 version", func() {
+		Expect(IsRKE2Version(k8sVersion)).To(BeFalse())
+	})
+})

--- a/test/e2e/data/infrastructure/cluster-template-docker.yaml
+++ b/test/e2e/data/infrastructure/cluster-template-docker.yaml
@@ -99,8 +99,8 @@ metadata:
   name: ${CLUSTER_NAME}-control-plane
 spec: 
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  version: ${KUBERNETES_VERSION}+rke2r1
   agentConfig:
-    version: ${KUBERNETES_VERSION}+rke2r1
     nodeAnnotations:
       test: "true"
   serverConfig:
@@ -135,7 +135,7 @@ spec:
       cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
   template:
     spec:
-      version: ${KUBERNETES_VERSION}
+      version: ${KUBERNETES_VERSION}+rke2r1
       clusterName: ${CLUSTER_NAME}
       bootstrap:
         configRef:
@@ -165,6 +165,5 @@ spec:
   template:
     spec:
       agentConfig:
-        version: ${KUBERNETES_VERSION}+rke2r1
         nodeAnnotations:
           test: "true"

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -33,14 +33,14 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 
+	controlplanev1alpha1 "github.com/rancher-sandbox/cluster-api-provider-rke2/controlplane/api/v1alpha1"
+	controlplanev1 "github.com/rancher-sandbox/cluster-api-provider-rke2/controlplane/api/v1beta1"
+	bsutil "github.com/rancher-sandbox/cluster-api-provider-rke2/pkg/util"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	controlplanev1alpha1 "github.com/rancher-sandbox/cluster-api-provider-rke2/controlplane/api/v1alpha1"
-	controlplanev1 "github.com/rancher-sandbox/cluster-api-provider-rke2/controlplane/api/v1beta1"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 // NOTE: the code in this file is largely copied from the cluster-api test framework with
@@ -436,7 +436,12 @@ func WaitForClusterToUpgrade(ctx context.Context, input WaitForClusterToUpgradeI
 		}
 
 		for _, machine := range machineList.Items {
-			if machine.Spec.Version != nil && *machine.Spec.Version != input.VersionAfterUpgrade {
+			expectedVersion := input.VersionAfterUpgrade
+			if bsutil.IsRKE2Version(*machine.Spec.Version) {
+				expectedVersion = input.VersionAfterUpgrade + "+rke2r1"
+			}
+
+			if machine.Spec.Version != nil && *machine.Spec.Version != expectedVersion {
 				return false, nil
 			}
 		}


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Use spec.Version field as primarily source of RKE2 version. Currently, it's just a placeholder for satisfying API contracts. When both spec.AgentConfig.Version and spec.Version are specified, spec.Version take precedence.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
