### PR TITLE
test: use gomega's ContainElements

### DIFF
--- a/pkg/registration/registration_test.go
+++ b/pkg/registration/registration_test.go
@@ -120,7 +120,8 @@ func TestInternalFirstMethod(t *testing.T) {
 			actualAddresses, err := regMethod(nil, tc.rcp, col)
 			g.Expect(err).NotTo(HaveOccurred())
 
-			g.Expect(actualAddresses).To(HaveExactElements(tc.expectedAddresses))
+			g.Expect(actualAddresses).To(HaveLen(len(tc.expectedAddresses)))
+			g.Expect(actualAddresses).To(ContainElements(tc.expectedAddresses))
 		})
 	}
 }
@@ -172,8 +173,8 @@ func TestInternalOnlyMethod(t *testing.T) {
 			actualAddresses, err := regMethod(nil, tc.rcp, col)
 			g.Expect(err).NotTo(HaveOccurred())
 
-			g.Expect(actualAddresses).To(HaveExactElements(tc.expectedAddresses))
-
+			g.Expect(actualAddresses).To(HaveLen(len(tc.expectedAddresses)))
+			g.Expect(actualAddresses).To(ContainElements(tc.expectedAddresses))
 		})
 	}
 }
@@ -225,8 +226,8 @@ func TestExternalOnlyMethod(t *testing.T) {
 			actualAddresses, err := regMethod(nil, tc.rcp, col)
 			g.Expect(err).NotTo(HaveOccurred())
 
-			g.Expect(actualAddresses).To(HaveExactElements(tc.expectedAddresses))
-
+			g.Expect(len(actualAddresses)).To(Equal(len(tc.expectedAddresses)))
+			g.Expect(actualAddresses).To(ContainElements(tc.expectedAddresses))
 		})
 	}
 }
@@ -276,8 +277,8 @@ func TestAddressMethod(t *testing.T) {
 
 			expectedAddresses := []string{"100.100.100.100"}
 
-			g.Expect(actualAddresses).To(HaveExactElements(expectedAddresses))
-
+			g.Expect(len(actualAddresses)).To(Equal(len(expectedAddresses)))
+			g.Expect(actualAddresses).To(ContainElements(expectedAddresses))
 		})
 	}
 }
@@ -336,8 +337,8 @@ func TestControlPlaneMethod(t *testing.T) {
 			g.Expect(err).NotTo(HaveOccurred())
 
 			expectedAddresses := []string{tc.expectedAddress}
-			g.Expect(actualAddresses).To(HaveExactElements(expectedAddresses))
-
+			g.Expect(len(actualAddresses)).To(Equal(len(expectedAddresses)))
+			g.Expect(actualAddresses).To(ContainElements(expectedAddresses))
 		})
 	}
 }
@@ -376,7 +377,6 @@ func createCluster(name string, cpHost string, cpPort int) *clusterv1.Cluster {
 	}
 
 	return cluster
-
 }
 
 func createMachine(name string, internalIPs []string, externalIPs []string) *clusterv1.Machine {


### PR DESCRIPTION
**What this PR does / why we need it**:

Gomega's `HaveExactElements` causes intermittent test failures because order is not guaranteed. Since order is not relevant in these scenarios, we could use the alternative `ContainElements`, which checks the content of the slice but not the order of its elements, plus length validation.

**Which issue(s) this PR fixes**:
Fixes #241 

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
