### PR TITLE
:bug: Check MachineConfig spec for full equality with Rke2CPSpec

### DIFF
--- a/pkg/rke2/machine_filters.go
+++ b/pkg/rke2/machine_filters.go
@@ -55,7 +55,7 @@ func matchesRKE2BootstrapConfig(machineConfigs map[string]*bootstrapv1.RKE2Confi
 		}
 
 		// Check if RCP AgentConfig and machineBootstrapConfig matches
-		return reflect.DeepEqual(machineConfig.Spec.AgentConfig, rcp.Spec.AgentConfig)
+		return reflect.DeepEqual(machineConfig.Spec, rcp.Spec.RKE2ConfigSpec)
 	}
 }
 

--- a/pkg/rke2/machine_filters_test.go
+++ b/pkg/rke2/machine_filters_test.go
@@ -94,6 +94,54 @@ var _ = Describe("matchAgentConfig", func() {
 		Expect(matches.Oldest().Name).To(Equal("machine-test"))
 	},
 	)
+
+	It("shouldn't match Agent Config and different preBootstrapCommands", func() {
+		machineConfigs := map[string]*bootstrapv1.RKE2Config{
+			"someMachine": {},
+			"machine-test": {
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "rke2-config-example",
+					Namespace: "example",
+				},
+				Spec: bootstrapv1.RKE2ConfigSpec{
+					AgentConfig: bootstrapv1.RKE2AgentConfig{
+						NodeLabels: []string{"hello=world"},
+					},
+					PreRKE2Commands: []string{"test"},
+				},
+			},
+		}
+		machineCollection := collections.FromMachines(&machine)
+		Expect(len(machineCollection)).To(Equal(1))
+		matches := machineCollection.AnyFilter(matchesRKE2BootstrapConfig(machineConfigs, &rcp))
+
+		Expect(len(matches)).To(Equal(0))
+	},
+	)
+
+	It("shouldn't match Agent Config and different postBootstrapCommands", func() {
+		machineConfigs := map[string]*bootstrapv1.RKE2Config{
+			"someMachine": {},
+			"machine-test": {
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "rke2-config-example",
+					Namespace: "example",
+				},
+				Spec: bootstrapv1.RKE2ConfigSpec{
+					AgentConfig: bootstrapv1.RKE2AgentConfig{
+						NodeLabels: []string{"hello=world"},
+					},
+					PostRKE2Commands: []string{"test"},
+				},
+			},
+		}
+		machineCollection := collections.FromMachines(&machine)
+		Expect(len(machineCollection)).To(Equal(1))
+		matches := machineCollection.AnyFilter(matchesRKE2BootstrapConfig(machineConfigs, &rcp))
+
+		Expect(len(matches)).To(Equal(0))
+	},
+	)
 })
 
 var _ = Describe("matching Kubernetes Version", func() {


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

We need to ensure that any change of `RKE2ConfigTemplate` is causing CP machines re-rollout.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #307 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
