### PR TITLE
docs: Set correct env var for template used in guide

### DIFF
--- a/docs/book/src/01_user/01_getting-started.md
+++ b/docs/book/src/01_user/01_getting-started.md
@@ -117,8 +117,8 @@ export NAMESPACE=example
 export CLUSTER_NAME=capd-rke2-test
 export CONTROL_PLANE_MACHINE_COUNT=3
 export WORKER_MACHINE_COUNT=2
-export KUBERNETES_VERSION=v1.30.3
-export KIND_IMAGE_VERSION=v1.30.3
+export KIND_IMAGE_VERSION=v1.31.4
+export RKE2_VERSION=v1.31.4+rke2r1
 ```
 
 The next step is to substitue the values in the YAML using the following commands:


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

The template referenced in user guide uses `RKE2_VERSION` not `KUBERNETES_VERSION`.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
