### PR TITLE
Rely on RKE2 managed etcd for member removal

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,26 +8,8 @@ on:
 
 jobs:
   e2e-tests:
-    runs-on: ubuntu-latest
+    runs-on: runs-on,runner=4cpu-linux-x64,run-id=${{ github.run_id }}
     steps:
-      - name: Cleanup space
-        run: |
-          # Cherry-pick from jlumbroso/free-disk-space@main
-          sudo apt-get remove -y '^aspnetcore-.*' || echo "::warning::The command [sudo apt-get remove -y '^aspnetcore-.*'] failed to complete successfully. Proceeding..."
-          sudo apt-get remove -y '^dotnet-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^dotnet-.*' --fix-missing] failed to complete successfully. Proceeding..."
-          sudo apt-get remove -y '^llvm-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^llvm-.*' --fix-missing] failed to complete successfully. Proceeding..."
-          sudo apt-get remove -y 'php.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y 'php.*' --fix-missing] failed to complete successfully. Proceeding..."
-          sudo apt-get remove -y '^mongodb-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^mongodb-.*' --fix-missing] failed to complete successfully. Proceeding..."
-          sudo apt-get remove -y '^mysql-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^mysql-.*' --fix-missing] failed to complete successfully. Proceeding..."
-          sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri --fix-missing || echo "::warning::The command [sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri --fix-missing] failed to complete successfully. Proceeding..."
-          sudo apt-get remove -y google-cloud-sdk --fix-missing || echo "::debug::The command [sudo apt-get remove -y google-cloud-sdk --fix-missing] failed to complete successfully. Proceeding..."
-          sudo apt-get remove -y google-cloud-cli --fix-missing || echo "::debug::The command [sudo apt-get remove -y google-cloud-cli --fix-missing] failed to complete successfully. Proceeding..."
-          sudo apt-get autoremove -y || echo "::warning::The command [sudo apt-get autoremove -y] failed to complete successfully. Proceeding..."
-          sudo apt-get clean || echo "::warning::The command [sudo apt-get clean] failed to complete successfully. Proceeding..."
-          sudo docker image prune --all --force || true
-          sudo swapoff -a || true
-          sudo rm -f /mnt/swapfile || true
-          free -h
       - name: Checkout code
         uses: actions/checkout@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -397,7 +397,7 @@ kubectl: # Download kubectl cli into tools bin folder
 
 # Allow overriding the e2e configurations
 GINKGO_FOCUS ?=
-GINKGO_SKIP ?= "Pivot"
+GINKGO_SKIP ?= "Pivot" # See: https://github.com/rancher/cluster-api-provider-rke2/issues/691 
 GINKGO_NODES ?= 1
 GINKGO_NOCOLOR ?= false
 GINKGO_ARGS ?=
@@ -409,7 +409,7 @@ SKIP_CLEANUP ?= false
 SKIP_CREATE_MGMT_CLUSTER ?= false
 
 .PHONY: test-e2e-run
-test-e2e-run: $(GINKGO) $(KUSTOMIZE) kubectl e2e-image e2e-image-store inotify-check ## Run the end-to-end tests
+test-e2e-run: $(GINKGO) $(KUSTOMIZE) kubectl e2e-image inotify-check ## Run the end-to-end tests
 	LOCAL_IMAGES="$(LOCAL_IMAGES)" CAPI_KUSTOMIZE_PATH="$(KUSTOMIZE)" $(GINKGO) -v -poll-progress-after=$(GINKGO_POLL_PROGRESS_AFTER) -poll-progress-interval=$(GINKGO_POLL_PROGRESS_INTERVAL) \
 	--tags=e2e --focus="$(GINKGO_FOCUS)" --skip="$(GINKGO_SKIP)" --nodes=$(GINKGO_NODES) --no-color=$(GINKGO_NOCOLOR) \
 	--timeout=$(GINKGO_TIMEOUT) --output-dir="$(ARTIFACTS)" --junit-report="junit.e2e_suite.1.xml" $(GINKGO_ARGS) ./test/e2e -- \
@@ -436,12 +436,6 @@ inotify-check:
 .PHONY: e2e-image
 e2e-image:
 	TAG=$(TAG) $(MAKE) docker-build
-
-.PHONY: e2e-image-store
-e2e-image-store: ## This is needed by the move/pivot e2e test to load images on the workload cluster.
-	mkdir -p $(LOCAL_IMAGES)
-	docker save $(BOOTSTRAP_IMG):$(TAG) > $(LOCAL_IMAGES)/bootstrap_dev.tar
-	docker save $(CONTROLPLANE_IMG):$(TAG) > $(LOCAL_IMAGES)/controlplane_dev.tar
 
 .PHONY: compile-e2e
 compile-e2e: ## Test e2e compilation

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/rancher/cluster-api-provider-rke2
 go 1.23.0
 
 require (
-	github.com/blang/semver/v4 v4.0.0
 	github.com/coreos/butane v0.24.0
 	github.com/coreos/ignition/v2 v2.21.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
@@ -47,6 +46,7 @@ require (
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/clarketm/json v1.17.1 // indirect

--- a/pkg/rke2/workload_cluster.go
+++ b/pkg/rke2/workload_cluster.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/blang/semver/v4"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -55,9 +54,6 @@ const (
 	rke2ServingSecretKey      = "rke2-serving" //nolint: gosec
 )
 
-// ErrControlPlaneMinNodes is returned when the control plane has fewer than 2 nodes.
-var ErrControlPlaneMinNodes = errors.New("cluster has fewer than 2 control plane nodes; removing an etcd member is not supported")
-
 // WorkloadCluster defines all behaviors necessary to upgrade kubernetes on a workload cluster.
 type WorkloadCluster interface {
 	// Basic health and status checks.
@@ -73,8 +69,8 @@ type WorkloadCluster interface {
 
 	// State recovery tasks.
 	RemoveEtcdMemberForMachine(ctx context.Context, machine *clusterv1.Machine) error
+	IsEtcdMemberSafelyRemovedForMachine(ctx context.Context, machine *clusterv1.Machine) (bool, error)
 	ForwardEtcdLeadership(ctx context.Context, machine *clusterv1.Machine, leaderCandidate *clusterv1.Machine) error
-	ReconcileEtcdMembers(ctx context.Context, nodeNames []string, version semver.Version) ([]string, error)
 	EtcdMembers(ctx context.Context) ([]string, error)
 }
 

--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -5,11 +5,11 @@ images:
     loadBehavior: mustLoad
   - name: ghcr.io/rancher/cluster-api-provider-rke2-controlplane:dev
     loadBehavior: mustLoad
-  - name: quay.io/jetstack/cert-manager-cainjector:v1.15.1
+  - name: quay.io/jetstack/cert-manager-cainjector:v1.16.3
     loadBehavior: tryLoad
-  - name: quay.io/jetstack/cert-manager-webhook:v1.15.1
+  - name: quay.io/jetstack/cert-manager-webhook:v1.16.3
     loadBehavior: tryLoad
-  - name: quay.io/jetstack/cert-manager-controller:v1.15.1
+  - name: quay.io/jetstack/cert-manager-controller:v1.16.3
     loadBehavior: tryLoad
 
 providers:
@@ -100,13 +100,13 @@ providers:
           new: "--leader-elect=false"
 
 variables:
-  KUBERNETES_VERSION_MANAGEMENT: "v1.29.2"
-  KUBERNETES_VERSION: "v1.30.4"
-  KIND_IMAGE_VERSION: "v1.30.4"
+  KUBERNETES_VERSION_MANAGEMENT: "v1.32.0"
+  KUBERNETES_VERSION: "v1.32.6"
+  KIND_IMAGE_VERSION: "v1.32.0"
   NODE_DRAIN_TIMEOUT: "60s"
   WORKER_MACHINE_COUNT: "2"
   CONTROL_PLANE_MACHINE_COUNT: "1"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.31.0"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.33.2"
   IP_FAMILY: "IPv4"
   EXP_CLUSTER_RESOURCE_SET: "true"
   EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION: "true"

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -222,6 +222,13 @@ func setupBootstrapCluster(config *clusterctl.E2EConfig, scheme *runtime.Scheme,
 		})
 		Expect(clusterProvider).ToNot(BeNil(), "Failed to create a bootstrap cluster")
 
+		localImagesPath := e2eConfig.GetVariable(LocalImages)
+		Byf("Storing Images in %s", localImagesPath)
+		Expect(StoreImages(ctx, StoreImagesInput{
+			Directory: localImagesPath,
+			Images:    config.Images,
+		})).Should(Succeed())
+
 		kubeconfigPath = clusterProvider.GetKubeconfigPath()
 		Expect(kubeconfigPath).To(BeAnExistingFile(), "Failed to get the kubeconfig file for the bootstrap cluster")
 	} else {

--- a/test/e2e/rcp_remediation_test.go
+++ b/test/e2e/rcp_remediation_test.go
@@ -21,6 +21,7 @@ package e2e
 
 import (
 	"os"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -43,6 +44,10 @@ var _ = Describe("When testing RCP remediation", func() {
 
 		By("Initializing the bootstrap cluster")
 		initBootstrapCluster(bootstrapClusterProxy, e2eConfig, clusterctlConfigPath, artifactFolder)
+
+		// Since the upstream KCPRemediatonSpec test has a 10 seconds hardcoded timeout on webhooks
+		// we are waiting here a bit to mitigate flakyness. For reference caprke2 tests normally timeout after 3 minutes.
+		time.Sleep(1 * time.Minute)
 	})
 
 	capi_e2e.KCPRemediationSpec(ctx, func() capi_e2e.KCPRemediationSpecInput {


### PR DESCRIPTION
**What this PR does / why we need it**:
A few changes regarding etcd reconciliation with this PR.

The summary is that caprke2 no longer tries to reconcile etcd member removal. 
The existing logic of removing the member works with etcd, but makes the rke2-server panic when there are no more voters on a node, creating the scenario for a known issue: https://github.com/rancher/rke2/issues/2829

Comparing with the Rancher provisioning API, seems that RKE2 has a different "managed" mechanism for etcd member removal, and that is to simply apply the `etcd.rke2.cattle.io/remove` annotation on the Node. 
After the member has been successfully removed, the `etcd.rke2.cattle.io/removed-node-name` annotation will be populated.
Reference: https://github.com/rancher/rancher/blob/release/v2.11/pkg/controllers/capr/etcdmgmt/saferemoval.go

caprke2 is now implementing the same logic.

Additionally, I removed all reconciliation code for etcd.
This logic ensured that if a Node was deleted, the related etcd member was also being removed.

However this is redundant with what RKE2 already does, so I simply removed the code.
Reference: https://github.com/k3s-io/k3s/blob/release-1.33/pkg/etcd/member_controller.go#L109

I left the "forward etcd leadership" logic in place. It's technically not necessary, but it makes rollouts smoother, since the leader is elected arbitrarily using the newest control plane node.

The pivot test is still flaky. 
On GitHub it fails consistently, during `clusterctl init` the workload cluster. Maybe using a [better runner](https://github.com/rancherlabs/eio/issues/3460) will improve this behavior.
Additionally, CAPD seems to be hanging from time to time. This also has to be [solved](https://github.com/rancher/cluster-api-provider-rke2/issues/691) for the test to be enabled. 
The test can be ran with `GINKGO_FOCUS="Pivot" GINKGO_SKIP="" make test-e2e`
If it gets stuck, the container simply needs a little kick: `docker start <containerid>`
 
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #655

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
