### PR TITLE
Add configurability for ClusterCache concurrency

### DIFF
--- a/controlplane/internal/controllers/rke2controlplane_controller.go
+++ b/controlplane/internal/controllers/rke2controlplane_controller.go
@@ -264,7 +264,10 @@ func patchRKE2ControlPlane(ctx context.Context, patchHelper *patch.Helper, rcp *
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *RKE2ControlPlaneReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, clientQPS float32, clientBurst, concurrency int) error {
+func (r *RKE2ControlPlaneReconciler) SetupWithManager(
+	ctx context.Context, mgr ctrl.Manager, clientQPS float32,
+	clientBurst, clusterCacheConcurrency, concurrency int,
+) error {
 	c, err := ctrl.NewControllerManagedBy(mgr).
 		For(&controlplanev1.RKE2ControlPlane{}).
 		Owns(&clusterv1.Machine{}).
@@ -314,7 +317,9 @@ func (r *RKE2ControlPlaneReconciler) SetupWithManager(ctx context.Context, mgr c
 				},
 			},
 		},
-	}, controller.Options{})
+	}, controller.Options{
+		MaxConcurrentReconciles: clusterCacheConcurrency,
+	})
 	if err != nil {
 		return errors.Wrap(err, "unable to create cluster cache tracker")
 	}

--- a/pkg/consts/global_consts.go
+++ b/pkg/consts/global_consts.go
@@ -39,6 +39,9 @@ const (
 	// DefaultSyncPeriod is the default resync period for the controller manager's cache.
 	DefaultSyncPeriod = 10 * time.Minute
 
+	// DefaultClusterCacheConcurrency is the default number of clusters that the controller can process simultaneously.
+	DefaultClusterCacheConcurrency = 100
+
 	// DefaultFileOwner is the default owner of the files created by the controller.
 	DefaultFileOwner = "root:root"
 


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This PR introduces a new command-line flag to configure the concurrency of the ClusterCache controller. This allows tuning the number of active workers, improving responsiveness and performance at scale.

**Special notes for your reviewer**:

- This change is similar to https://github.com/rancher/cluster-api-provider-rke2/pull/624. 
- The default concurrency value was borrowed from the [kubeadm provider](https://github.com/kubernetes-sigs/cluster-api/blob/main/controlplane/kubeadm/main.go#L156), which serves as a relevant reference point.
- Some lines were broken into multiple lines to comply with linter requirements.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
