### PR TITLE
Update control plane label

### DIFF
--- a/controlplane/internal/controllers/lifecycle_hook_test.go
+++ b/controlplane/internal/controllers/lifecycle_hook_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Lifecycle Hooks", Ordered, func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-node",
 				Labels: map[string]string{
-					"node-role.kubernetes.io/master": "true",
+					"node-role.kubernetes.io/control-plane": "true",
 				},
 				Annotations: map[string]string{
 					clusterv1.MachineAnnotation: "test-node",

--- a/controlplane/internal/controllers/rke2controlplane_controller_test.go
+++ b/controlplane/internal/controllers/rke2controlplane_controller_test.go
@@ -192,7 +192,7 @@ var _ = Describe("Reconcile control plane conditions", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: nodeName,
 				Labels: map[string]string{
-					"node-role.kubernetes.io/master": "true",
+					"node-role.kubernetes.io/control-plane": "true",
 				},
 				Annotations: map[string]string{
 					clusterv1.MachineAnnotation: nodeName,
@@ -259,7 +259,7 @@ var _ = Describe("Reconcile control plane conditions", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: nodeRefName,
 				Labels: map[string]string{
-					"node-role.kubernetes.io/master": "true",
+					"node-role.kubernetes.io/control-plane": "true",
 				},
 				Annotations: map[string]string{
 					clusterv1.MachineAnnotation: machineWithRef.Name,
@@ -279,7 +279,7 @@ var _ = Describe("Reconcile control plane conditions", func() {
 		orphanedNode = &corev1.Node{ObjectMeta: metav1.ObjectMeta{
 			Name: "missing-machine",
 			Labels: map[string]string{
-				"node-role.kubernetes.io/master": "true",
+				"node-role.kubernetes.io/control-plane": "true",
 			},
 		}}
 		Expect(testEnv.Create(ctx, orphanedNode)).To(Succeed())

--- a/examples/templates/aws/cluster-template-ignition.yaml
+++ b/examples/templates/aws/cluster-template-ignition.yaml
@@ -210,7 +210,7 @@ data:
             k8s-app: aws-cloud-controller-manager
         spec:
           nodeSelector:
-            node-role.kubernetes.io/master: "true"
+            node-role.kubernetes.io/control-plane: "true"
           tolerations:
             - key: node.cloudprovider.kubernetes.io/uninitialized
               value: "true"

--- a/examples/templates/aws/cluster-template.yaml
+++ b/examples/templates/aws/cluster-template.yaml
@@ -285,7 +285,7 @@ data:
             k8s-app: aws-cloud-controller-manager
         spec:
           nodeSelector:
-            node-role.kubernetes.io/master: "true"
+            node-role.kubernetes.io/control-plane: "true"
           tolerations:
             - key: node.cloudprovider.kubernetes.io/uninitialized
               value: "true"

--- a/pkg/rke2/workload_cluster.go
+++ b/pkg/rke2/workload_cluster.go
@@ -46,7 +46,7 @@ import (
 )
 
 const (
-	labelNodeRoleControlPlane = "node-role.kubernetes.io/master"
+	labelNodeRoleControlPlane = "node-role.kubernetes.io/control-plane"
 	remoteEtcdTimeout         = 30 * time.Second
 	etcdDialTimeout           = 10 * time.Second
 	etcdCallTimeout           = 15 * time.Second

--- a/pkg/rke2/workload_cluster_test.go
+++ b/pkg/rke2/workload_cluster_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Node metadata propagation", func() {
 		node = &corev1.Node{ObjectMeta: metav1.ObjectMeta{
 			Name: nodeName,
 			Labels: map[string]string{
-				"node-role.kubernetes.io/master": "true",
+				"node-role.kubernetes.io/control-plane": "true",
 			},
 			Annotations: map[string]string{
 				clusterv1.MachineAnnotation: nodeName,
@@ -436,7 +436,7 @@ var _ = Describe("ClusterStatus validation", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "node1",
 				Labels: map[string]string{
-					"node-role.kubernetes.io/master": "true",
+					"node-role.kubernetes.io/control-plane": "true",
 				},
 				Annotations: map[string]string{
 					clusterv1.MachineAnnotation: "node1",
@@ -454,7 +454,7 @@ var _ = Describe("ClusterStatus validation", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "node2",
 				Labels: map[string]string{
-					"node-role.kubernetes.io/master": "true",
+					"node-role.kubernetes.io/control-plane": "true",
 				},
 				Annotations: map[string]string{
 					clusterv1.MachineAnnotation: "node2",


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request updates the control plane label to "node-role.kubernetes.io/control-plane" to ensure compatibility with newer versions of RKE2.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #760

**Special notes for your reviewer**:
None
