### PR TITLE
test: bump capi to v1.12.2

### DIFF
--- a/test/e2e/config/e2e_conf.yaml
+++ b/test/e2e/config/e2e_conf.yaml
@@ -16,8 +16,8 @@ providers:
   - name: cluster-api
     type: CoreProvider
     versions:
-      - name: "v1.11.5"
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.5/core-components.yaml"
+      - name: "v1.12.2"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.2/core-components.yaml"
         type: "url"
         contract: v1beta2
         files:
@@ -30,8 +30,8 @@ providers:
   - name: docker
     type: InfrastructureProvider
     versions:
-      - name: "v1.11.5"
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.5/infrastructure-components-development.yaml"
+      - name: "v1.12.2"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.2/infrastructure-components-development.yaml"
         type: "url"
         contract: v1beta2
         files:

--- a/test/e2e/data/shared/v1beta1/metadata.yaml
+++ b/test/e2e/data/shared/v1beta1/metadata.yaml
@@ -2,6 +2,9 @@ apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 kind: Metadata
 releaseSeries:
   - major: 1
+    minor: 12
+    contract: v1beta2
+  - major: 1
     minor: 11
     contract: v1beta2
   - major: 1

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -273,10 +273,10 @@ func initUpgradableBootstrapCluster(bootstrapClusterProxy framework.ClusterProxy
 	InitManagementCluster(context.TODO(), clusterctl.InitManagementClusterAndWatchControllerLogsInput{
 		ClusterProxy:              bootstrapClusterProxy,
 		ClusterctlConfigPath:      clusterctlConfig,
-		InfrastructureProviders:   []string{"docker:v1.11.5"},
+		InfrastructureProviders:   []string{"docker:v1.12.2"},
 		IPAMProviders:             config.IPAMProviders(),
 		RuntimeExtensionProviders: config.RuntimeExtensionProviders(),
-		CoreProvider:              "cluster-api:v1.11.5",
+		CoreProvider:              "cluster-api:v1.12.2",
 		BootstrapProviders:        []string{"rke2-bootstrap:v0.22.0"},
 		ControlPlaneProviders:     []string{"rke2-control-plane:v0.22.0"},
 		LogFolder:                 filepath.Join(artifactFolder, "clusters", bootstrapClusterProxy.GetName()),

--- a/test/e2e/e2e_upgrade_test.go
+++ b/test/e2e/e2e_upgrade_test.go
@@ -153,8 +153,8 @@ var _ = Describe("Provider upgrade", Label(UpgradeTestsLabel), func() {
 			UpgradeManagementCluster(ctx, clusterctl.UpgradeManagementClusterAndWaitInput{
 				ClusterProxy:            bootstrapClusterProxy,
 				ClusterctlConfigPath:    clusterctlConfigPath,
-				InfrastructureProviders: []string{"docker:v1.11.5"},
-				CoreProvider:            "cluster-api:v1.11.5",
+				InfrastructureProviders: []string{"docker:v1.12.2"},
+				CoreProvider:            "cluster-api:v1.12.2",
 				BootstrapProviders:      []string{"rke2-bootstrap:v0.23.99"},
 				ControlPlaneProviders:   []string{"rke2-control-plane:v0.23.99"},
 				LogFolder:               clusterctlLogFolder,

--- a/test/e2e/rcp_remediation_test.go
+++ b/test/e2e/rcp_remediation_test.go
@@ -57,7 +57,7 @@ var _ = Describe("When testing RCP remediation", Label(DefaultTestsLabel), func(
 			BootstrapClusterProxy:  bootstrapClusterProxy,
 			ArtifactFolder:         artifactFolder,
 			SkipCleanup:            skipCleanup,
-			InfrastructureProvider: ptr.To("docker:v1.11.5"),
+			InfrastructureProvider: ptr.To("docker:v1.12.2"),
 			Flavor:                 ptr.To("kcp-remediation"),
 		}
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump CAPI to v1.12.2 in E2E tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

This should be backported to `release-0.23`.

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
