### PR TITLE
Handle deletion conditions for v1beta2 API

### DIFF
--- a/controlplane/internal/controllers/status.go
+++ b/controlplane/internal/controllers/status.go
@@ -102,6 +102,12 @@ func (r *RKE2ControlPlaneReconciler) updateStatus(ctx context.Context, rcp *cont
 		controlPlane.Cluster, controlPlane.RCP, controlPlane.Machines, controlPlane.InfraMachineTemplateIsNotFound, controlPlane.PreflightCheckResults)
 	setScalingDownCondition(ctx, controlPlane.Cluster, controlPlane.RCP, controlPlane.Machines, controlPlane.PreflightCheckResults)
 	setMachinesReadyCondition(ctx, controlPlane.RCP, controlPlane.Machines)
+
+	// Return early if the deletion timestamp is set. The DeletingCondition is set directly in reconcileDelete.
+	if !rcp.DeletionTimestamp.IsZero() {
+		return nil
+	}
+
 	setDeletingCondition(ctx, controlPlane.RCP, controlPlane.DeletingReason, controlPlane.DeletingMessage)
 
 	kubeconfigSecret := corev1.Secret{}


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This PR fixes deletion conditions for v1beta2 API. However to fully fix failures in the CI a PR for CAPD is required too, if we don't delete resources in order CAPD infra cluster is gone before CAPD machines are and controller starts failing.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/rancher/cluster-api-provider-rke2/issues/821

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
