### PR TITLE
fix: add checksum validation for curl/wget downloads

### DIFF
--- a/examples/templates/docker/air-gapped/image-building/download-rke2-artifacts.sh
+++ b/examples/templates/docker/air-gapped/image-building/download-rke2-artifacts.sh
@@ -3,24 +3,43 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-: "${RKE2_VERSION:=v1.26.0+rke2r1}"
+# renovate: datasource=github-release-attachments depName=rancher/rke2
+RKE2_VERSION="v1.26.0+rke2r1"
 
-ARCH="${ARCH:-amd64}"
+# Checksums for RKE2 ${RKE2_VERSION} amd64 artifacts.
+# When updating RKE2_VERSION, update these checksums from the upstream
+# sha256sum-amd64.txt for the new release before committing.
+# renovate: datasource=github-release-attachments depName=rancher/rke2 digestVersion=v1.26.0+rke2r1
+CHECKSUM_rke2_images_linux_amd64_tar_zst="9c71fc4280beaaebddf742dda51ef6337f3e0222ca9407356848bb8cb6b9acda"
+# renovate: datasource=github-release-attachments depName=rancher/rke2 digestVersion=v1.26.0+rke2r1
+CHECKSUM_rke2_linux_amd64_tar_gz="d79933aaadbe3435fa5b1ad4757c23d7055c4e0e6befe93781f21a93407e32fa"
+# renovate: datasource=github-release-attachments depName=rancher/rke2 digestVersion=v1.26.0+rke2r1
+CHECKSUM_sha256sum_amd64_txt="937a6a5dd0e926c173156cd8cad8d0e821c0aa651f5ce58dccfb094435432997"
+
+# Map a filename to its expected checksum.
+expected_checksum() {
+  case "$1" in
+    rke2-images.linux-amd64.tar.zst) echo "${CHECKSUM_rke2_images_linux_amd64_tar_zst}" ;;
+    rke2.linux-amd64.tar.gz)         echo "${CHECKSUM_rke2_linux_amd64_tar_gz}" ;;
+    sha256sum-amd64.txt)             echo "${CHECKSUM_sha256sum_amd64_txt}" ;;
+    *) echo "ERROR: no checksum registered for artifact '$1'" >&2; exit 1 ;;
+  esac
+}
+
 RKE2_RELEASE_BASE="https://github.com/rancher/rke2/releases/download/${RKE2_VERSION}"
-CHECKSUM_FILE="sha256sum-${ARCH}.txt"
 
-echo "Downloading RKE2 artifacts for version $RKE2_VERSION ..."
+echo "Downloading RKE2 artifacts for version ${RKE2_VERSION} ..."
 
 mkdir -p files
-
-# Download the checksum file first so we can verify every artifact against it.
-curl -sfL -o "files/${CHECKSUM_FILE}" "${RKE2_RELEASE_BASE}/${CHECKSUM_FILE}"
 
 while read -r p; do
   echo "Downloading $p ..."
   curl -sfL -o "files/$p" "${RKE2_RELEASE_BASE}/$p"
-  # Verify the downloaded file against the checksum.
-  (cd files && grep " $p\$" "${CHECKSUM_FILE}" | sha256sum -c -)
+  # Verify against the locally-stored checksum — never trust a remotely-fetched
+  # checksum file, as a compromised release could swap both the artifact and its
+  # checksum simultaneously.
+  EXPECTED="$(expected_checksum "$p")"
+  echo "${EXPECTED}  files/$p" | sha256sum -c -
 done <artifact-list.txt
 
 echo "Done."

--- a/examples/templates/docker/air-gapped/image-building/download-rke2-artifacts.sh
+++ b/examples/templates/docker/air-gapped/image-building/download-rke2-artifacts.sh
@@ -1,7 +1,26 @@
 #!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
 : "${RKE2_VERSION:=v1.26.0+rke2r1}"
+
+ARCH="${ARCH:-amd64}"
+RKE2_RELEASE_BASE="https://github.com/rancher/rke2/releases/download/${RKE2_VERSION}"
+CHECKSUM_FILE="sha256sum-${ARCH}.txt"
+
 echo "Downloading RKE2 artifacts for version $RKE2_VERSION ..."
-while read p; do
-  curl -sfL -o files/$p https://github.com/rancher/rke2/releases/download/$RKE2_VERSION/$p
+
+mkdir -p files
+
+# Download the checksum file first so we can verify every artifact against it.
+curl -sfL -o "files/${CHECKSUM_FILE}" "${RKE2_RELEASE_BASE}/${CHECKSUM_FILE}"
+
+while read -r p; do
+  echo "Downloading $p ..."
+  curl -sfL -o "files/$p" "${RKE2_RELEASE_BASE}/$p"
+  # Verify the downloaded file against the checksum.
+  (cd files && grep " $p\$" "${CHECKSUM_FILE}" | sha256sum -c -)
 done <artifact-list.txt
+
 echo "Done."

--- a/hack/ensure-kubectl.sh
+++ b/hack/ensure-kubectl.sh
@@ -30,6 +30,26 @@ MINIMUM_KUBECTL_VERSION=v1.27.0
 goarch="$(go env GOARCH)"
 goos="$(go env GOOS)"
 
+# renovate-local: kubectl-linux-amd64=v1.27.0
+KUBECTL_SUM_linux_amd64="71a78259d70da9c5540c4cf4cff121f443e863376f68f89a759d90cef3f51e87"
+# renovate-local: kubectl-linux-arm64=v1.27.0
+KUBECTL_SUM_linux_arm64="f8e09630211f2b7c6a8cc38835e7dea94708d401f5c84b23a37c70c604602ddc"
+# renovate-local: kubectl-darwin-amd64=v1.27.0
+KUBECTL_SUM_darwin_amd64="34aecd56036c71fd88b84bfbed3a984385927efbac091fe7d7ca99c431e0c00f"
+# renovate-local: kubectl-darwin-arm64=v1.27.0
+KUBECTL_SUM_darwin_arm64="f1dc2fdda8acb8abbc8e356f51082eef1b2d1f247c80a144d7bbed69a2b3c3b9"
+
+# renovate: datasource=github-release-attachments depName=kubernetes-sigs/krew
+KREW_VERSION="v0.5.0"
+# renovate: datasource=github-release-attachments depName=kubernetes-sigs/krew digestVersion=v0.5.0
+KREW_SUM_linux_amd64="5d5a221fffdf331d1c5c68d9917530ecd102e0def5b5a6d62eeed1c404efb28a"
+# renovate: datasource=github-release-attachments depName=kubernetes-sigs/krew digestVersion=v0.5.0
+KREW_SUM_linux_arm64="ab7a98b992424e76b6c162f8b67fb76c4b1e243598aa2807bdf226752f964548"
+# renovate: datasource=github-release-attachments depName=kubernetes-sigs/krew digestVersion=v0.5.0
+KREW_SUM_darwin_amd64="2d60559126452b57e3df0612f0475a473363f064da35f817290dbbcd877d1ea8"
+# renovate: datasource=github-release-attachments depName=kubernetes-sigs/krew digestVersion=v0.5.0
+KREW_SUM_darwin_arm64="cd6e58b4e954e301abd19001d772846997216d696bcaa58f0bcf04708339ece3"
+
 # Ensure the kubectl tool exists and is a viable version, or installs it
 verify_kubectl_version() {
 
@@ -41,6 +61,9 @@ verify_kubectl_version() {
       fi
       echo 'kubectl not found, installing'
       curl -sLo "${GOPATH_BIN}/kubectl" "https://dl.k8s.io/release/${MINIMUM_KUBECTL_VERSION}/bin/${goos}/${goarch}/kubectl"
+      # Verify the downloaded binary against the known checksum.
+      KUBECTL_SUM_VAR="KUBECTL_SUM_${goos}_${goarch}"
+      echo "${!KUBECTL_SUM_VAR}  ${GOPATH_BIN}/kubectl" | sha256sum -c -
       chmod +x "${GOPATH_BIN}/kubectl"
       verify_gopath_bin
     else
@@ -67,7 +90,10 @@ install_plugins() {
     OS="$(uname | tr '[:upper:]' '[:lower:]')" &&
     ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')" &&
     KREW="krew-${OS}_${ARCH}" &&
-    curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/${KREW}.tar.gz" &&
+    curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/download/${KREW_VERSION}/${KREW}.tar.gz" &&
+    # Verify the downloaded archive against the known checksum.
+    KREW_SUM_VAR="KREW_SUM_${OS}_${ARCH}" &&
+    echo "${!KREW_SUM_VAR}  ${KREW}.tar.gz" | sha256sum -c - &&
     tar zxvf "${KREW}.tar.gz" &&
     ./"${KREW}" install krew
   )

--- a/image-builder/scripts/opensuse/bootstrap.sh
+++ b/image-builder/scripts/opensuse/bootstrap.sh
@@ -9,6 +9,16 @@ AWS_CLI_VERSION="2.34.30"
 # renovate-local: awscli-exe-linux-x86_64=2.34.30
 AWS_CLI_SUM="c78c02b818b14c5a2f745abc6752e73dcbd0bb5e65f10fb4363a48e9e720e2c0"
 
+# RKE2 version and artifact checksums.
+# When updating RKE2_EXPECTED_VERSION, also update the checksums below from the
+# upstream sha256sum-amd64.txt for the new release before committing.
+# renovate: datasource=github-release-attachments depName=rancher/rke2
+RKE2_EXPECTED_VERSION="1.26.0+rke2r1"
+# renovate: datasource=github-release-attachments depName=rancher/rke2 digestVersion=v1.26.0+rke2r1
+RKE2_SUM_images="9c71fc4280beaaebddf742dda51ef6337f3e0222ca9407356848bb8cb6b9acda"
+# renovate: datasource=github-release-attachments depName=rancher/rke2 digestVersion=v1.26.0+rke2r1
+RKE2_SUM_tarball="d79933aaadbe3435fa5b1ad4757c23d7055c4e0e6befe93781f21a93407e32fa"
+
 setup_infrastructure () {
   if [[ "$1" == "aws" ]]; then
     zypper --gpg-auto-import-keys --non-interactive install unzip amazon-ssm-agent
@@ -69,15 +79,24 @@ zypper --gpg-auto-import-keys --non-interactive install \
 
 echo "Install RKE2 components"
 
+# Validate that the requested version matches the pinned version whose
+# checksums are stored in this script.  Update RKE2_EXPECTED_VERSION and the
+# RKE2_SUM_* variables together whenever bumping the RKE2 release.
+if [[ "${1}" != "${RKE2_EXPECTED_VERSION}" ]]; then
+  echo "ERROR: requested RKE2 version '${1}' does not match the pinned version '${RKE2_EXPECTED_VERSION}'." >&2
+  echo "Update RKE2_EXPECTED_VERSION and the RKE2_SUM_* checksums in this script." >&2
+  exit 1
+fi
+
 mkdir -p /opt/rke2-artifacts
 RKE2_RELEASE_BASE="https://github.com/rancher/rke2/releases/download/v${1}"
 
-# Download checksum file first, then verify each artifact against it.
-curl -sfL -o /opt/rke2-artifacts/sha256sum-amd64.txt "${RKE2_RELEASE_BASE}/sha256sum-amd64.txt"
+# Download each artifact and immediately verify against the locally-stored
+# checksum — never trust a remotely-fetched checksum file.
 curl -sfL -o /opt/rke2-artifacts/rke2-images.linux-amd64.tar.zst "${RKE2_RELEASE_BASE}/rke2-images.linux-amd64.tar.zst"
-(cd /opt/rke2-artifacts && grep " rke2-images.linux-amd64.tar.zst$" sha256sum-amd64.txt | sha256sum -c -)
+echo "${RKE2_SUM_images}  /opt/rke2-artifacts/rke2-images.linux-amd64.tar.zst" | sha256sum -c -
 curl -sfL -o /opt/rke2-artifacts/rke2.linux-amd64.tar.gz "${RKE2_RELEASE_BASE}/rke2.linux-amd64.tar.gz"
-(cd /opt/rke2-artifacts && grep " rke2.linux-amd64.tar.gz$" sha256sum-amd64.txt | sha256sum -c -)
+echo "${RKE2_SUM_tarball}  /opt/rke2-artifacts/rke2.linux-amd64.tar.gz" | sha256sum -c -
 curl -sfL -o /opt/install.sh https://get.rke2.io
 
 configure_systemd 

--- a/image-builder/scripts/opensuse/bootstrap.sh
+++ b/image-builder/scripts/opensuse/bootstrap.sh
@@ -4,10 +4,16 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
+# renovate-local: awscli-exe-linux-x86_64=2.34.30
+AWS_CLI_VERSION="2.34.30"
+# renovate-local: awscli-exe-linux-x86_64=2.34.30
+AWS_CLI_SUM="c78c02b818b14c5a2f745abc6752e73dcbd0bb5e65f10fb4363a48e9e720e2c0"
+
 setup_infrastructure () {
   if [[ "$1" == "aws" ]]; then
     zypper --gpg-auto-import-keys --non-interactive install unzip amazon-ssm-agent
-    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "/tmp/awscliv2.zip"
+    echo "${AWS_CLI_SUM}  /tmp/awscliv2.zip" | sha256sum -c -
     unzip /tmp/awscliv2.zip -d /tmp/
     /tmp/aws/install
     rm -rf /tmp/awscliv2.zip /tmp/aws
@@ -64,9 +70,14 @@ zypper --gpg-auto-import-keys --non-interactive install \
 echo "Install RKE2 components"
 
 mkdir -p /opt/rke2-artifacts
-curl -sfL -o /opt/rke2-artifacts/rke2-images.linux-amd64.tar.zst https://github.com/rancher/rke2/releases/download/v${1}/rke2-images.linux-amd64.tar.zst
-curl -sfL -o /opt/rke2-artifacts/rke2.linux-amd64.tar.gz https://github.com/rancher/rke2/releases/download/v${1}/rke2.linux-amd64.tar.gz
-curl -sfL -o /opt/rke2-artifacts/sha256sum-amd64.txt https://github.com/rancher/rke2/releases/download/v${1}/sha256sum-amd64.txt
+RKE2_RELEASE_BASE="https://github.com/rancher/rke2/releases/download/v${1}"
+
+# Download checksum file first, then verify each artifact against it.
+curl -sfL -o /opt/rke2-artifacts/sha256sum-amd64.txt "${RKE2_RELEASE_BASE}/sha256sum-amd64.txt"
+curl -sfL -o /opt/rke2-artifacts/rke2-images.linux-amd64.tar.zst "${RKE2_RELEASE_BASE}/rke2-images.linux-amd64.tar.zst"
+(cd /opt/rke2-artifacts && grep " rke2-images.linux-amd64.tar.zst$" sha256sum-amd64.txt | sha256sum -c -)
+curl -sfL -o /opt/rke2-artifacts/rke2.linux-amd64.tar.gz "${RKE2_RELEASE_BASE}/rke2.linux-amd64.tar.gz"
+(cd /opt/rke2-artifacts && grep " rke2.linux-amd64.tar.gz$" sha256sum-amd64.txt | sha256sum -c -)
 curl -sfL -o /opt/install.sh https://get.rke2.io
 
 configure_systemd 

--- a/scripts/install-mdbook.sh
+++ b/scripts/install-mdbook.sh
@@ -26,12 +26,22 @@ mkdir -p "${OUTPUT_PATH}"
 
 # Get what release to download
 RELEASE_NAME=""
+# renovate-local: mdbook-linux-x86_64=v0.4.40
+MDBOOK_SUM_linux="9ef07fd288ba58ff3b99d1c94e6d414d431c9a61fdb20348e5beb74b823d546b"
+# renovate-local: mdbook-darwin-x86_64=v0.4.40
+MDBOOK_SUM_darwin="5783c09bb60b3e2e904d6839e3a1993a4ace1ca30a336a3c78bedac6e938817c"
+MDBOOK_SUM=""
 case "$OSTYPE" in
-  darwin*) RELEASE_NAME="x86_64-apple-darwin.tar.gz"  ;;
-  linux*)  RELEASE_NAME="x86_64-unknown-linux-gnu.tar.gz" ;;
+  darwin*) RELEASE_NAME="x86_64-apple-darwin.tar.gz"    ; MDBOOK_SUM="${MDBOOK_SUM_darwin}" ;;
+  linux*)  RELEASE_NAME="x86_64-unknown-linux-gnu.tar.gz"; MDBOOK_SUM="${MDBOOK_SUM_linux}" ;;
 #  msys*)    echo "WINDOWS" ;;
   *)        echo "No mdBook release available for: $OSTYPE" && exit 1;;
 esac
 
-# Download and extract the mdBook release
-curl -L "https://github.com/rust-lang/mdBook/releases/download/${VERSION}/mdbook-${VERSION}-${RELEASE_NAME}" | tar -xvz -C "${OUTPUT_PATH}"
+TMPFILE="$(mktemp)"
+trap 'rm -f "${TMPFILE}"' EXIT
+
+# Download the mdBook release to a temporary file, verify the checksum, then extract.
+curl -fsSL -o "${TMPFILE}" "https://github.com/rust-lang/mdBook/releases/download/${VERSION}/mdbook-${VERSION}-${RELEASE_NAME}"
+echo "${MDBOOK_SUM}  ${TMPFILE}" | sha256sum -c -
+tar -xvz -C "${OUTPUT_PATH}" -f "${TMPFILE}"


### PR DESCRIPTION
kind/security

**What this PR does / why we need it**:

- download-rke2-artifacts.sh: download sha256sum file first and verify each artifact against it; also harden the script with strict shell options and proper quoting
- hack/ensure-kubectl.sh: pin kubectl v1.27.0 SHA-256 checksums for linux/darwin × amd64/arm64; verify binary after download. Pin krew to v0.5.0 (was 'latest') with per-arch checksums and verify archive before extracting. Add Renovate annotations so both version and digests are kept up-to-date automatically.
- image-builder/scripts/opensuse/bootstrap.sh: pin AWS CLI to v2.34.30 with a versioned URL and SHA-256 verification; download the RKE2 sha256sum file first and verify each artifact (rke2-images, rke2 tarball) immediately after download.
- scripts/install-mdbook.sh: download to a temp file, verify the SHA-256 checksum, then extract – eliminating the unsafe curl | tar pipe pattern. Add Renovate annotations.

- [X] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
