### PR TITLE
ci: migrate release workflow to publish-image action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         go-version-file: go.mod
     - name: "Read secrets"
-      uses: rancher-eio/read-vault-secrets@main
+      uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89
       with:
         secrets: |
           secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials username | DOCKER_USERNAME ;
@@ -34,7 +34,7 @@ jobs:
           secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials password | PRIME_REGISTRY_PASSWORD ;
 
     - name: Push bootstrap image to public
-      uses: rancher/ecm-distro-tools/actions/publish-image@master
+      uses: rancher/ecm-distro-tools/actions/publish-image@5d6e63896fea85836b2fca6dfb9236bcefe2aaa5
       with:
         image: cluster-api-provider-rke2-bootstrap
         tag: ${{ github.ref_name }}
@@ -47,7 +47,7 @@ jobs:
 
     - name: Push bootstrap image to prime
       if: ${{ !contains(github.ref_name, '-rc') }}
-      uses: rancher/ecm-distro-tools/actions/publish-image@master
+      uses: rancher/ecm-distro-tools/actions/publish-image@5d6e63896fea85836b2fca6dfb9236bcefe2aaa5
       with:
         image: cluster-api-provider-rke2-bootstrap
         tag: ${{ github.ref_name }}
@@ -60,7 +60,7 @@ jobs:
         prime-make-target: push-prime-image-bootstrap
 
     - name: Push controlplane image to public
-      uses: rancher/ecm-distro-tools/actions/publish-image@master
+      uses: rancher/ecm-distro-tools/actions/publish-image@5d6e63896fea85836b2fca6dfb9236bcefe2aaa5
       with:
         image: cluster-api-provider-rke2-controlplane
         tag: ${{ github.ref_name }}
@@ -73,7 +73,7 @@ jobs:
 
     - name: Push controlplane image to prime
       if: ${{ !contains(github.ref_name, '-rc') }}
-      uses: rancher/ecm-distro-tools/actions/publish-image@master
+      uses: rancher/ecm-distro-tools/actions/publish-image@5d6e63896fea85836b2fca6dfb9236bcefe2aaa5
       with:
         image: cluster-api-provider-rke2-controlplane
         tag: ${{ github.ref_name }}
@@ -101,7 +101,7 @@ jobs:
       with:
         go-version-file: go.mod
     - name: Read prime registry secrets
-      uses: rancher-eio/read-vault-secrets@main
+      uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89
       with:
         secrets: |
           secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials username | PRIME_REGISTRY_USERNAME ;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: release
+name: Release
 
 on:
   push:
@@ -7,16 +7,13 @@ on:
 
 env:
   TAG: ${{ github.ref_name }}
-  GHCR_REGISTRY: ghcr.io
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  publish-images:
     permissions:
       contents: read
-      packages: write
-      actions: read
       id-token: write
+    runs-on: runs-on,runner=8cpu-linux-x64,run-id=${{ github.run_id }},image=ubuntu22-full-x64
     steps:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -26,35 +23,74 @@ jobs:
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version-file: go.mod
-    - name: Docker login ghcr.io
-      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
-      with:
-        registry: ${{ env.GHCR_REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build and push docker image to ghcr.io
-      run: make docker-build-and-push TAG=${{ env.TAG }} REGISTRY=${{ env.GHCR_REGISTRY }}
-    - name: Read prime registry secrets
-      uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
+    - name: "Read secrets"
+      uses: rancher-eio/read-vault-secrets@main
       with:
         secrets: |
-          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials username |  PRIME_REGISTRY_USERNAME;
-          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials password |  PRIME_REGISTRY_PASSWORD;
-          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials registry |  PRIME_REGISTRY;
-    - name: Docker login to prime registry
-      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+          secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials username | DOCKER_USERNAME ;
+          secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials password | DOCKER_PASSWORD ;
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials registry | PRIME_REGISTRY ;
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials username | PRIME_REGISTRY_USERNAME ;
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials password | PRIME_REGISTRY_PASSWORD ;
+
+    - name: Push bootstrap image to public
+      uses: rancher/ecm-distro-tools/actions/publish-image@master
       with:
-        registry: ${{ env.PRIME_REGISTRY }}
-        username: ${{ env.PRIME_REGISTRY_USERNAME }}
-        password: ${{ env.PRIME_REGISTRY_PASSWORD }}
-    - name: Build and push docker image to prime registry
-      run: make docker-build-and-push TAG=${{ env.TAG }} REGISTRY=${{ env.PRIME_REGISTRY }}
+        image: cluster-api-provider-rke2-bootstrap
+        tag: ${{ github.ref_name }}
+        platforms: linux/amd64,linux/arm64
+        push-to-prime: false
+        public-repo: rancher
+        public-username: ${{ env.DOCKER_USERNAME }}
+        public-password: ${{ env.DOCKER_PASSWORD }}
+        make-target: push-image-bootstrap
+
+    - name: Push bootstrap image to prime
+      if: ${{ !contains(github.ref_name, '-rc') }}
+      uses: rancher/ecm-distro-tools/actions/publish-image@master
+      with:
+        image: cluster-api-provider-rke2-bootstrap
+        tag: ${{ github.ref_name }}
+        platforms: linux/amd64,linux/arm64
+        push-to-public: false
+        prime-repo: rancher
+        prime-registry: ${{ env.PRIME_REGISTRY }}
+        prime-username: ${{ env.PRIME_REGISTRY_USERNAME }}
+        prime-password: ${{ env.PRIME_REGISTRY_PASSWORD }}
+        prime-make-target: push-prime-image-bootstrap
+
+    - name: Push controlplane image to public
+      uses: rancher/ecm-distro-tools/actions/publish-image@master
+      with:
+        image: cluster-api-provider-rke2-controlplane
+        tag: ${{ github.ref_name }}
+        platforms: linux/amd64,linux/arm64
+        push-to-prime: false
+        public-repo: rancher
+        public-username: ${{ env.DOCKER_USERNAME }}
+        public-password: ${{ env.DOCKER_PASSWORD }}
+        make-target: push-image-controlplane
+
+    - name: Push controlplane image to prime
+      if: ${{ !contains(github.ref_name, '-rc') }}
+      uses: rancher/ecm-distro-tools/actions/publish-image@master
+      with:
+        image: cluster-api-provider-rke2-controlplane
+        tag: ${{ github.ref_name }}
+        platforms: linux/amd64,linux/arm64
+        push-to-public: false
+        prime-repo: rancher
+        prime-registry: ${{ env.PRIME_REGISTRY }}
+        prime-username: ${{ env.PRIME_REGISTRY_USERNAME }}
+        prime-password: ${{ env.PRIME_REGISTRY_PASSWORD }}
+        prime-make-target: push-prime-image-controlplane
+
   release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
       id-token: write
-    needs: [build]
+    needs: [publish-images]
     steps:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -65,15 +101,15 @@ jobs:
       with:
         go-version-file: go.mod
     - name: Read prime registry secrets
-      uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
+      uses: rancher-eio/read-vault-secrets@main
       with:
         secrets: |
-          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials username |  PRIME_REGISTRY_USERNAME;
-          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials password |  PRIME_REGISTRY_PASSWORD;
-          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials registry |  PRIME_REGISTRY;
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials username | PRIME_REGISTRY_USERNAME ;
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials password | PRIME_REGISTRY_PASSWORD ;
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials registry | PRIME_REGISTRY ;
     - name: Update manifests
       run: |
-        make release RELEASE_TAG=${{ env.TAG }} REGISTRY=${{ env.GHCR_REGISTRY }}
+        make release RELEASE_TAG=${{ env.TAG }} REGISTRY=docker.io
     - name: Package and publish release manifests as OCI artifacts
       env:
         ORAS_VERSION: 1.2.3
@@ -126,3 +162,4 @@ jobs:
         gh release upload ${{ env.TAG }} out/metadata.yaml
         gh release upload ${{ env.TAG }} out/bootstrap-components.yaml
         gh release upload ${{ env.TAG }} out/control-plane-components.yaml
+

--- a/Makefile
+++ b/Makefile
@@ -543,7 +543,41 @@ docker-build-and-push-rke2-controlplane:
 			--build-arg ldflags="$(LDFLAGS)" . -t $(CONTROLPLANE_IMG):$(TAG)
 	$(MAKE) set-manifest-pull-policy TARGET_RESOURCE="./controlplane/config/default/manager_pull_policy.yaml"
 
-.PHONY: set-manifest-pull-policy
+.PHONY: push-image-bootstrap
+push-image-bootstrap: buildx-machine ## Build and push bootstrap image via docker buildx (called by publish-image action).
+	DOCKER_BUILDKIT=1 BUILDX_BUILDER=$(MACHINE) docker buildx build \
+			$(IID_FILE_FLAG) \
+			$(BUILDX_ARGS) \
+			--platform $(TARGET_PLATFORMS) \
+			--push \
+			--build-arg builder_image=$(GO_CONTAINER_IMAGE) \
+			--build-arg goproxy=$(GOPROXY) \
+			--build-arg package=./bootstrap \
+			--build-arg ldflags="$(LDFLAGS)" . -t $(IMAGE_NAME)
+
+.PHONY: push-prime-image-bootstrap
+push-prime-image-bootstrap: ## Build and push bootstrap image to prime with SBOM and provenance attestations.
+	BUILDX_ARGS="--sbom=true --attest type=provenance,mode=max" \
+	$(MAKE) push-image-bootstrap
+
+.PHONY: push-image-controlplane
+push-image-controlplane: buildx-machine ## Build and push controlplane image via docker buildx (called by publish-image action).
+	DOCKER_BUILDKIT=1 BUILDX_BUILDER=$(MACHINE) docker buildx build \
+			$(IID_FILE_FLAG) \
+			$(BUILDX_ARGS) \
+			--platform $(TARGET_PLATFORMS) \
+			--push \
+			--build-arg builder_image=$(GO_CONTAINER_IMAGE) \
+			--build-arg goproxy=$(GOPROXY) \
+			--build-arg package=./controlplane \
+			--build-arg ldflags="$(LDFLAGS)" . -t $(IMAGE_NAME)
+
+.PHONY: push-prime-image-controlplane
+push-prime-image-controlplane: ## Build and push controlplane image to prime with SBOM and provenance attestations.
+	BUILDX_ARGS="--sbom=true --attest type=provenance,mode=max" \
+	$(MAKE) push-image-controlplane
+
+
 set-manifest-pull-policy:
 	$(info Updating kustomize pull policy file for manager resources)
 	sed -i'' -e 's@imagePullPolicy: .*@imagePullPolicy: '"$(PULL_POLICY)"'@' $(TARGET_RESOURCE)


### PR DESCRIPTION
## What changed

- Replace manual GHCR/prime `docker-build-and-push` with `rancher/ecm-distro-tools/actions/publish-image`
- Read DockerHub and prime credentials from Vault via `rancher-eio/read-vault-secrets`
- Switch `publish-images` job to `runs-on` 8cpu-linux-x64 runner as recommended
- Add separate publish-image steps for bootstrap and controlplane images
- Guard prime pushes behind rc check to avoid pre-release images in prime
- Add `push-image-bootstrap`, `push-image-controlplane` and prime variants to Makefile
- Update `make release` to point manifests at `docker.io` instead of `ghcr.io`
- Pin `read-vault-secrets` and `publish-image` to specific SHA commits