### PR TITLE
bump go to 1.25.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/cluster-api-provider-rke2
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/coreos/butane v0.27.0

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/cluster-api-provider-rke2/hack/tools
 
-go 1.25.8
+go 1.25.9
 
 require sigs.k8s.io/cluster-api/hack/tools v0.0.0-20240820112706-3abe3058a6a8
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a number of CVEs:
- [CVE-2026-32280](https://github.com/advisories/GHSA-m4pr-4j3g-9v7v)
- [CVE-2026-32282](https://github.com/advisories/GHSA-xj38-jxc5-rppx)
- [CVE-2026-32281](https://github.com/advisories/GHSA-gjvh-7jh8-7xhm)
- [CVE-2026-32288](https://github.com/advisories/GHSA-x4jj-h2v8-hqqv)
- [CVE-2026-32289](https://github.com/advisories/GHSA-7mr4-xjxg-34g6)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
