### PR TITLE
Add CRDMigrator for automatic v1beta1->v1beta2 migration

### DIFF
--- a/bootstrap/config/rbac/role.yaml
+++ b/bootstrap/config/rbac/role.yaml
@@ -19,6 +19,25 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resourceNames:
+  - rke2configs.bootstrap.cluster.x-k8s.io
+  - rke2configtemplates.bootstrap.cluster.x-k8s.io
+  resources:
+  - customresourcedefinitions
+  - customresourcedefinitions/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -44,6 +63,23 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - bootstrap.cluster.x-k8s.io
+  resources:
+  - rke2configtemplates
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - bootstrap.cluster.x-k8s.io
+  resources:
+  - rke2configtemplates/status
+  verbs:
+  - patch
+  - update
 - apiGroups:
   - cluster.x-k8s.io
   resources:

--- a/bootstrap/main.go
+++ b/bootstrap/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -28,6 +29,7 @@ import (
 
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -35,9 +37,11 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/cluster-api/controllers/crdmigrator"
 	"sigs.k8s.io/cluster-api/feature"
 	"sigs.k8s.io/cluster-api/util/flags"
 
@@ -67,6 +71,7 @@ var (
 	webhookPort                 int
 	webhookCertDir              string
 	healthAddr                  string
+	skipCRDMigrationPhases      []string
 	managerOptions              = flags.ManagerOptions{}
 )
 
@@ -83,6 +88,7 @@ func init() {
 	utilruntime.Must(bootstrapv1.AddToScheme(scheme))
 	utilruntime.Must(bootstrapv1beta1.AddToScheme(scheme))
 	utilruntime.Must(clusterv1.AddToScheme(scheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 } //nolint:wsl
 
@@ -123,6 +129,9 @@ func InitFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&healthAddr, "health-addr", ":9440",
 		"The address the health endpoint binds to.")
 
+	fs.StringSliceVar(&skipCRDMigrationPhases, "skip-crd-migration-phases", []string{},
+		"List of CRD migration phases to skip. Valid values are: All, StorageVersionMigration, CleanupManagedFields.")
+
 	flags.AddManagerOptions(fs, &managerOptions)
 
 	feature.MutableGates.AddFlag(fs)
@@ -131,6 +140,14 @@ func InitFlags(fs *pflag.FlagSet) {
 // Add RBAC for the authorized diagnostics endpoint.
 // +kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
 // +kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
+
+// ADD CRD RBAC for CRD Migrator.
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions;customresourcedefinitions/status,verbs=update;patch,resourceNames=rke2configs.bootstrap.cluster.x-k8s.io;rke2configtemplates.bootstrap.cluster.x-k8s.io
+
+// ADD CR RBAC for CRD Migrator.
+// +kubebuilder:rbac:groups=bootstrap.cluster.x-k8s.io,resources=rke2configtemplates,verbs=get;list;watch;patch;update
+// +kubebuilder:rbac:groups=bootstrap.cluster.x-k8s.io,resources=rke2configtemplates/status,verbs=patch;update
 
 func main() {
 	InitFlags(pflag.CommandLine)
@@ -197,7 +214,7 @@ func main() {
 	ctx := ctrl.SetupSignalHandler()
 
 	setupChecks(mgr)
-	setupReconcilers(mgr)
+	setupReconcilers(ctx, mgr)
 	setupWebhooks(mgr)
 
 	setupLog.Info("Starting manager", "version", version.Get().String(), "concurrency", concurrencyNumber)
@@ -220,12 +237,32 @@ func setupChecks(mgr ctrl.Manager) {
 	}
 }
 
-func setupReconcilers(mgr ctrl.Manager) {
+func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 	if err := (&controllers.RKE2ConfigReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr, concurrencyNumber); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Rke2Config")
+		os.Exit(1)
+	}
+
+	crdMigratorConfig := map[client.Object]crdmigrator.ByObjectConfig{
+		&bootstrapv1.RKE2Config{}:         {UseCache: true, UseStatusForStorageVersionMigration: true},
+		&bootstrapv1.RKE2ConfigTemplate{}: {UseCache: false, UseStatusForStorageVersionMigration: true},
+	}
+
+	crdMigratorSkipPhases := []crdmigrator.Phase{}
+	for _, p := range skipCRDMigrationPhases {
+		crdMigratorSkipPhases = append(crdMigratorSkipPhases, crdmigrator.Phase(p))
+	}
+
+	if err := (&crdmigrator.CRDMigrator{
+		Client:                 mgr.GetClient(),
+		APIReader:              mgr.GetAPIReader(),
+		SkipCRDMigrationPhases: crdMigratorSkipPhases,
+		Config:                 crdMigratorConfig,
+	}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "CRDMigrator")
 		os.Exit(1)
 	}
 }

--- a/controlplane/config/rbac/role.yaml
+++ b/controlplane/config/rbac/role.yaml
@@ -27,6 +27,17 @@ rules:
   - list
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resourceNames:
+  - rke2controlplanes.controlplane.cluster.x-k8s.io
+  - rke2controlplanetemplates.controlplane.cluster.x-k8s.io
+  resources:
+  - customresourcedefinitions
+  - customresourcedefinitions/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -93,6 +104,16 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
+  - rke2controlplanetemplates
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - infrastructure.cluster.x-k8s.io
   resources:

--- a/controlplane/main.go
+++ b/controlplane/main.go
@@ -45,6 +45,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/api/runtime/hooks/v1alpha1"
 	runtimev1 "sigs.k8s.io/cluster-api/api/runtime/v1beta2"
+	"sigs.k8s.io/cluster-api/controllers/crdmigrator"
 	runtimecatalog "sigs.k8s.io/cluster-api/exp/runtime/catalog"
 	runtimeclient "sigs.k8s.io/cluster-api/exp/runtime/client"
 	"sigs.k8s.io/cluster-api/feature"
@@ -85,6 +86,7 @@ var (
 	runtimeExtensionCertFile       string
 	runtimeExtensionKeyFile        string
 	healthAddr                     string
+	skipCRDMigrationPhases         []string
 	managerOptions                 = flags.ManagerOptions{}
 )
 
@@ -156,6 +158,9 @@ func InitFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&healthAddr, "health-addr", ":9440",
 		"The address the health endpoint binds to.")
 
+	fs.StringSliceVar(&skipCRDMigrationPhases, "skip-crd-migration-phases", []string{},
+		"List of CRD migration phases to skip. Valid values are: All, StorageVersionMigration, CleanupManagedFields.")
+
 	flags.AddManagerOptions(fs, &managerOptions)
 
 	feature.MutableGates.AddFlag(fs)
@@ -164,6 +169,12 @@ func InitFlags(fs *pflag.FlagSet) {
 // Add RBAC for the authorized diagnostics endpoint.
 // +kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
 // +kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
+
+// ADD CRD RBAC for CRD Migrator.
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions;customresourcedefinitions/status,verbs=update;patch,resourceNames=rke2controlplanes.controlplane.cluster.x-k8s.io;rke2controlplanetemplates.controlplane.cluster.x-k8s.io
+
+// ADD CR RBAC for CRD Migrator.
+// +kubebuilder:rbac:groups=controlplane.cluster.x-k8s.io,resources=rke2controlplanetemplates,verbs=get;list;watch;patch;update
 
 func main() {
 	klog.InitFlags(nil)
@@ -321,6 +332,26 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 		clusterCacheConcurrencyNumber, concurrencyNumber,
 	); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "RKE2ControlPlane")
+		os.Exit(1)
+	}
+
+	crdMigratorConfig := map[client.Object]crdmigrator.ByObjectConfig{
+		&controlplanev1.RKE2ControlPlane{}:         {UseCache: true, UseStatusForStorageVersionMigration: true},
+		&controlplanev1.RKE2ControlPlaneTemplate{}: {UseCache: false},
+	}
+
+	crdMigratorSkipPhases := []crdmigrator.Phase{}
+	for _, p := range skipCRDMigrationPhases {
+		crdMigratorSkipPhases = append(crdMigratorSkipPhases, crdmigrator.Phase(p))
+	}
+
+	if err := (&crdmigrator.CRDMigrator{
+		Client:                 mgr.GetClient(),
+		APIReader:              mgr.GetAPIReader(),
+		SkipCRDMigrationPhases: crdMigratorSkipPhases,
+		Config:                 crdMigratorConfig,
+	}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "CRDMigrator")
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This PR adds CRDMigrator controller from Core CAPI, it's used to help migrate CRDs to a newer API version automatically. The change is useful for CAPRKE2 users who want to fully switch from v1beta1 to v1beta2.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
