### PR TITLE
feat: use publish image action in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,33 +22,71 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         fetch-depth: 0
-    - name: setupGo
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
-      with:
-        go-version-file: go.mod
-    - name: Docker login ghcr.io
-      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
-      with:
-        registry: ${{ env.GHCR_REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build and push docker image to ghcr.io
-      run: make docker-build-and-push TAG=${{ env.TAG }} REGISTRY=${{ env.GHCR_REGISTRY }}
+
     - name: Read prime registry secrets
       uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
       with:
         secrets: |
-          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials username |  PRIME_REGISTRY_USERNAME;
-          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials password |  PRIME_REGISTRY_PASSWORD;
-          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials registry |  PRIME_REGISTRY;
-    - name: Docker login to prime registry
-      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials username | PRIME_REGISTRY_USERNAME;
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials password | PRIME_REGISTRY_PASSWORD;
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials registry | PRIME_REGISTRY;
+
+    - name: Push bootstrap image to ghcr.io
+      uses: rancher/ecm-distro-tools/actions/publish-image@df88359100d76a6d1d6ba91fae417d9afca7da48
       with:
-        registry: ${{ env.PRIME_REGISTRY }}
-        username: ${{ env.PRIME_REGISTRY_USERNAME }}
-        password: ${{ env.PRIME_REGISTRY_PASSWORD }}
-    - name: Build and push docker image to prime registry
-      run: make docker-build-and-push TAG=${{ env.TAG }} REGISTRY=${{ env.PRIME_REGISTRY }}
+        image: cluster-api-provider-rke2-bootstrap
+        tag: ${{ env.TAG }}
+        platforms: linux/amd64,linux/arm64
+        push-to-public: true
+        push-to-prime: false
+        public-registry: ${{ env.GHCR_REGISTRY }}
+        public-repo: rancher
+        public-username: ${{ github.actor }}
+        public-password: ${{ secrets.GITHUB_TOKEN }}
+        make-target: push-rke2-bootstrap-image
+
+    - name: Push controlplane image to ghcr.io
+      uses: rancher/ecm-distro-tools/actions/publish-image@df88359100d76a6d1d6ba91fae417d9afca7da48
+      with:
+        image: cluster-api-provider-rke2-controlplane
+        tag: ${{ env.TAG }}
+        platforms: linux/amd64,linux/arm64
+        push-to-public: true
+        push-to-prime: false
+        public-registry: ${{ env.GHCR_REGISTRY }}
+        public-repo: rancher
+        public-username: ${{ github.actor }}
+        public-password: ${{ secrets.GITHUB_TOKEN }}
+        make-target: push-rke2-controlplane-image
+
+    - name: Push bootstrap image to prime registry
+      uses: rancher/ecm-distro-tools/actions/publish-image@df88359100d76a6d1d6ba91fae417d9afca7da48
+      with:
+        image: cluster-api-provider-rke2-bootstrap
+        tag: ${{ env.TAG }}
+        platforms: linux/amd64,linux/arm64
+        push-to-public: false
+        push-to-prime: true
+        prime-repo: rancher
+        prime-registry: ${{ env.PRIME_REGISTRY }}
+        prime-username: ${{ env.PRIME_REGISTRY_USERNAME }}
+        prime-password: ${{ env.PRIME_REGISTRY_PASSWORD }}
+        prime-make-target: push-rke2-bootstrap-image
+
+    - name: Push controlplane image to prime registry
+      uses: rancher/ecm-distro-tools/actions/publish-image@df88359100d76a6d1d6ba91fae417d9afca7da48
+      with:
+        image: cluster-api-provider-rke2-controlplane
+        tag: ${{ env.TAG }}
+        platforms: linux/amd64,linux/arm64
+        push-to-public: false
+        push-to-prime: true
+        prime-repo: rancher
+        prime-registry: ${{ env.PRIME_REGISTRY }}
+        prime-username: ${{ env.PRIME_REGISTRY_USERNAME }}
+        prime-password: ${{ env.PRIME_REGISTRY_PASSWORD }}
+        prime-make-target: push-rke2-controlplane-image
+
   release:
     runs-on: ubuntu-latest
     permissions:
@@ -89,40 +127,46 @@ jobs:
             && wget -q https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz \
             && tar -xzf oras_${ORAS_VERSION}_linux_amd64.tar.gz \
             && sudo install -D -m 755 oras /usr/local/bin/
-        
+
         echo "Authenticating with registry..."
         echo "${REGISTRY_PASSWORD}" | oras login "${REGISTRY_HOST}" --username "${REGISTRY_USERNAME}" --password-stdin
-        
+
         cd out
         echo "Pushing artifacts to registry: ${ARTIFACT_NAME}:${{ env.TAG }}"
         echo "Files in out directory:"
         ls -la
-        
+
         FILES_TO_PUSH="metadata.yaml bootstrap-components.yaml control-plane-components.yaml"
-        
+
         MISSING_FILES=""
         for file in $FILES_TO_PUSH; do
           if [ ! -f "$file" ]; then
             MISSING_FILES="$MISSING_FILES $file"
           fi
         done
-        
+
         if [ -n "$MISSING_FILES" ]; then
           echo "ERROR: Missing files:$MISSING_FILES"
           exit 1
         fi
-        
+
         if oras push "${ARTIFACT_NAME}:${{ env.TAG }}" $FILES_TO_PUSH; then
           echo "Successfully pushed artifacts"
         else
           echo "ERROR: Failed to push artifacts"
           exit 1
         fi
-    - name: Release
+
+    - name: Create draft release
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         gh release create ${{ env.TAG }} --draft --generate-notes
+
+    - name: Upload release assets
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
         gh release upload ${{ env.TAG }} out/metadata.yaml
         gh release upload ${{ env.TAG }} out/bootstrap-components.yaml
         gh release upload ${{ env.TAG }} out/control-plane-components.yaml

--- a/Makefile
+++ b/Makefile
@@ -510,37 +510,39 @@ release-notes: $(RELEASE_DIR) $(GH)
 ## Docker
 ## --------------------------------------
 
-.PHONY: docker-build-and-push
-docker-build-and-push: buildx-machine docker-pull-prerequisites
-	$(MAKE) docker-build-and-push-rke2-bootstrap
-	$(MAKE) docker-build-and-push-rke2-controlplane
+# The following targets are called by the publish-image action in the release workflow.
+# See .github/workflows/release.yaml for details.
 
-.PHONY: docker-build-and-push-rke2-bootstrap
-docker-build-and-push-rke2-bootstrap:
-	DOCKER_BUILDKIT=1 BUILDX_BUILDER=$(MACHINE) docker buildx build \
-			--platform $(TARGET_PLATFORMS) \
-			--push \
-			--sbom=true \
-			--attest type=provenance,mode=max \
-			--iidfile=$(IID_FILE) \
-			--build-arg builder_image=$(GO_CONTAINER_IMAGE) \
-			--build-arg goproxy=$(GOPROXY) \
-			--build-arg package=./bootstrap \
-			--build-arg ldflags="$(LDFLAGS)" . -t $(BOOTSTRAP_IMG):$(TAG)
+REPO ?= $(REGISTRY)/$(ORG)
+
+.PHONY: push-rke2-bootstrap-image
+push-rke2-bootstrap-image: docker-pull-prerequisites ## Build and push bootstrap image (called by publish-image action)
+	DOCKER_BUILDKIT=1 docker buildx build \
+		$(IID_FILE_FLAG) \
+		$(BUILDX_ARGS) \
+		--platform=$(TARGET_PLATFORMS) \
+		--push \
+		--sbom=true \
+		--attest type=provenance,mode=max \
+		--build-arg builder_image=$(GO_CONTAINER_IMAGE) \
+		--build-arg goproxy=$(GOPROXY) \
+		--build-arg package=./bootstrap \
+		--build-arg ldflags="$(LDFLAGS)" . -t $(REPO)/$(BOOTSTRAP_IMAGE_NAME):$(TAG)
 	$(MAKE) set-manifest-pull-policy TARGET_RESOURCE="./bootstrap/config/default/manager_pull_policy.yaml"
 
-.PHONY: docker-build-and-push-rke2-controlplane
-docker-build-and-push-rke2-controlplane:
-	DOCKER_BUILDKIT=1 BUILDX_BUILDER=$(MACHINE) docker buildx build \
-			--platform $(TARGET_PLATFORMS) \
-			--push \
-			--sbom=true \
-			--attest type=provenance,mode=max \
-			--iidfile=$(IID_FILE) \
-			--build-arg builder_image=$(GO_CONTAINER_IMAGE) \
-			--build-arg goproxy=$(GOPROXY) \
-			--build-arg package=./controlplane \
-			--build-arg ldflags="$(LDFLAGS)" . -t $(CONTROLPLANE_IMG):$(TAG)
+.PHONY: push-rke2-controlplane-image
+push-rke2-controlplane-image: docker-pull-prerequisites ## Build and push controlplane image (called by publish-image action)
+	DOCKER_BUILDKIT=1 docker buildx build \
+		$(IID_FILE_FLAG) \
+		$(BUILDX_ARGS) \
+		--platform=$(TARGET_PLATFORMS) \
+		--push \
+		--sbom=true \
+		--attest type=provenance,mode=max \
+		--build-arg builder_image=$(GO_CONTAINER_IMAGE) \
+		--build-arg goproxy=$(GOPROXY) \
+		--build-arg package=./controlplane \
+		--build-arg ldflags="$(LDFLAGS)" . -t $(REPO)/$(CONTROLPLANE_IMAGE_NAME):$(TAG)
 	$(MAKE) set-manifest-pull-policy TARGET_RESOURCE="./controlplane/config/default/manager_pull_policy.yaml"
 
 .PHONY: set-manifest-pull-policy


### PR DESCRIPTION
**What this PR does / why we need it**:

Adapt the release workflow to use the publish image action. 

~Blocked on https://github.com/rancherlabs/slsactl/pull/313 to be merged first to pass a provenance verification and https://github.com/rancher/ecm-distro-tools/pull/924 to consume new version of publish image action~

Tested on fork: https://github.com/furkatgofurov7/cluster-api-provider-rke2/actions/runs/26460975530

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
