### PR TITLE
bump go to v1.25.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/cluster-api-provider-rke2
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/coreos/butane v0.27.0

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/cluster-api-provider-rke2/hack/tools
 
-go 1.25.9
+go 1.25.10
 
 require sigs.k8s.io/cluster-api/hack/tools v0.0.0-20240820112706-3abe3058a6a8
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Go 1.25.10 introduces several security patches.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
