### PR TITLE
Add additionalPrinterColumns to RKE2ControlPlane

### DIFF
--- a/controlplane/api/v1beta2/rke2controlplane_types.go
+++ b/controlplane/api/v1beta2/rke2controlplane_types.go
@@ -318,6 +318,17 @@ type RKE2ControlPlaneInitializationStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
+// +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels['cluster\\.x-k8s\\.io/cluster-name']",description="Cluster"
+// +kubebuilder:printcolumn:name="Available",type="string",JSONPath=`.status.conditions[?(@.type=="Available")].status`,description="Cluster pass all availability checks"
+// +kubebuilder:printcolumn:name="Desired",type=integer,JSONPath=".spec.replicas",description="The desired number of machines"
+// +kubebuilder:printcolumn:name="Current",type="integer",JSONPath=".status.replicas",description="The number of machines"
+// +kubebuilder:printcolumn:name="Ready",type="integer",JSONPath=".status.readyReplicas",description="The number of machines with Ready condition true"
+// +kubebuilder:printcolumn:name="Available",type=integer,JSONPath=".status.availableReplicas",description="The number of machines with Available condition true"
+// +kubebuilder:printcolumn:name="Up-to-date",type=integer,JSONPath=".status.upToDateReplicas",description="The number of machines with UpToDate condition true"
+// +kubebuilder:printcolumn:name="Paused",type="string",JSONPath=`.status.conditions[?(@.type=="Paused")].status`,description="Reconciliation paused",priority=10
+// +kubebuilder:printcolumn:name="Initialized",type=boolean,JSONPath=".status.initialization.controlPlaneInitialized",description="This denotes whether or not the control plane can accept requests"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of RKE2ControlPlane"
+// +kubebuilder:printcolumn:name="Version",type=string,JSONPath=".spec.version",description="Kubernetes version associated with this control plane"
 
 // RKE2ControlPlane is the Schema for the rke2controlplanes API.
 type RKE2ControlPlane struct {

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanes.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_rke2controlplanes.yaml
@@ -1652,7 +1652,53 @@ spec:
     storage: false
     subresources:
       status: {}
-  - name: v1beta2
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .metadata.labels['cluster\.x-k8s\.io/cluster-name']
+      name: Cluster
+      type: string
+    - description: Cluster pass all availability checks
+      jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
+      type: string
+    - description: The desired number of machines
+      jsonPath: .spec.replicas
+      name: Desired
+      type: integer
+    - description: The number of machines
+      jsonPath: .status.replicas
+      name: Current
+      type: integer
+    - description: The number of machines with Ready condition true
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: The number of machines with Available condition true
+      jsonPath: .status.availableReplicas
+      name: Available
+      type: integer
+    - description: The number of machines with UpToDate condition true
+      jsonPath: .status.upToDateReplicas
+      name: Up-to-date
+      type: integer
+    - description: Reconciliation paused
+      jsonPath: .status.conditions[?(@.type=="Paused")].status
+      name: Paused
+      priority: 10
+      type: string
+    - description: This denotes whether or not the control plane can accept requests
+      jsonPath: .status.initialization.controlPlaneInitialized
+      name: Initialized
+      type: boolean
+    - description: Time duration since creation of RKE2ControlPlane
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Kubernetes version associated with this control plane
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    name: v1beta2
     schema:
       openAPIV3Schema:
         description: RKE2ControlPlane is the Schema for the rke2controlplanes API.


### PR DESCRIPTION
kind/feature

**What this PR does / why we need it**:

Adds `additionalPrinterColumns` to the `RKE2ControlPlane` CRD.

This improves the user experience when inspecting control plane resources by exposing key status information directly through kubectl get, reducing the need to inspect individual resources with kubectl describe or kubectl get -o yaml.

Before:
```
$ kubectl get rke2controlplane
NAME                    AGE
aripoll-testing-pmtn7   16h
```

After:
```
$ kubectl get rke2controlplane
NAME                    CLUSTER           AVAILABLE   DESIRED   CURRENT   READY   AVAILABLE   UP-TO-DATE   INITIALIZED   AGE   VERSION
aripoll-testing-pmtn7   aripoll-testing   True        1         1         1       1           1            true          16h   v1.34.8+rke2r2
```

The selected columns are aligned with the KubeadmControlPlane reference implementation in Cluster API, providing a consistent operational experience across control plane providers.

**Special notes for your reviewer**:

This is for consistent operational experience only. No functional behavior is changed.
The implementation follows the same approach used by the KubeadmControlPlane CRD in Cluster API.

**Checklist**:

- [X] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
