### PR TITLE
fix: include cacert in cache key

### DIFF
--- a/pkg/rke2/management_cluster.go
+++ b/pkg/rke2/management_cluster.go
@@ -21,6 +21,7 @@ import (
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -70,11 +71,13 @@ type Management struct {
 type ClientCertEntry struct {
 	Cluster    ctrlclient.ObjectKey
 	ClientCert *tls.Certificate
+	CACert     []byte
 }
 
 // Key returns the cache key of a ClientCertEntry.
+// It includes a fingerprint of the etcd CA so that a CA change invalidates the entry.
 func (r ClientCertEntry) Key() string {
-	return r.Cluster.String()
+	return fmt.Sprintf("%s:%x", r.Cluster.String(), sha256.Sum256(r.CACert))
 }
 
 // RemoteClusterConnectionError represents a failure to connect to a remote cluster.

--- a/pkg/rke2/workload_cluster.go
+++ b/pkg/rke2/workload_cluster.go
@@ -122,8 +122,8 @@ func (m *Management) NewWorkload(ctx context.Context, cl ctrlclient.Client, rest
 
 	if !strings.Contains(string(etcdKeyPair.Key), "EC PRIVATE KEY") {
 		// Get client cert from cache if possible, otherwise generate it and add it to the cache.
-		// Note: The caching assumes that the etcd CA is not rotated during the lifetime of a Cluster.
-		if entry, ok := m.ClientCertCache.Has(ClientCertEntry{Cluster: clusterKey}.Key()); ok {
+		// The cache key includes the etcd CA, so a rotated CA invalidates the cache.
+		if entry, ok := m.ClientCertCache.Has(ClientCertEntry{Cluster: clusterKey, CACert: etcdKeyPair.Cert}.Key()); ok {
 			clientCert = *entry.ClientCert
 		} else {
 			// The client cert expires after 10 years, but that's okay as the cache has a TTL of 1 day.
@@ -132,7 +132,7 @@ func (m *Management) NewWorkload(ctx context.Context, cl ctrlclient.Client, rest
 				return nil, err
 			}
 
-			m.ClientCertCache.Add(ClientCertEntry{Cluster: clusterKey, ClientCert: &clientCert})
+			m.ClientCertCache.Add(ClientCertEntry{Cluster: clusterKey, ClientCert: &clientCert, CACert: etcdKeyPair.Cert})
 		}
 	}
 


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

The cache key for the client certificate included only the cluster namespace/name. If a new cluster gets recreated with the same name in the same namespace before the cache expires, it will try to use the cached client certificate to connect. But since the new cluster has a new CA, it will fail to connect. The fix includes the CA fingerprint in the cache entry. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #919 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
