### PR TITLE
edge-2287 addressing rke2-install depending on dbus.service as it is using systemctl

### DIFF
--- a/bootstrap/internal/ignition/butane/butane.go
+++ b/bootstrap/internal/ignition/butane/butane.go
@@ -52,8 +52,8 @@ systemd:
       contents: |
         [Unit]
         Description=rke2-install
-        Wants=network-online.target
-        After=network-online.target network.target
+        Wants=network-online.target dbus.service
+        After=network-online.target network.target dbus.service
         ConditionPathExists=!/etc/cluster-api/bootstrap-success.complete
         [Service]
         User=root

--- a/bootstrap/internal/ignition/butane/butane_test.go
+++ b/bootstrap/internal/ignition/butane/butane_test.go
@@ -118,7 +118,7 @@ var _ = Describe("Render", func() {
 
 		Expect(ign.Systemd.Units).To(HaveLen(3))
 		Expect(ign.Systemd.Units[0].Name).To(Equal("rke2-install.service"))
-		Expect(ign.Systemd.Units[0].Contents).To(Equal(ptr.To("[Unit]\nDescription=rke2-install\nWants=network-online.target\nAfter=network-online.target network.target\nConditionPathExists=!/etc/cluster-api/bootstrap-success.complete\n[Service]\nUser=root\n# To not restart the unit when it exits, as it is expected.\nType=oneshot\nExecStart=/etc/rke2-install.sh\n[Install]\nWantedBy=multi-user.target\n")))
+		Expect(ign.Systemd.Units[0].Contents).To(Equal(ptr.To("[Unit]\nDescription=rke2-install\nWants=network-online.target dbus.service\nAfter=network-online.target network.target dbus.service\nConditionPathExists=!/etc/cluster-api/bootstrap-success.complete\n[Service]\nUser=root\n# To not restart the unit when it exits, as it is expected.\nType=oneshot\nExecStart=/etc/rke2-install.sh\n[Install]\nWantedBy=multi-user.target\n")))
 		Expect(ign.Systemd.Units[0].Enabled).To(Equal(ptr.To(true)))
 
 		Expect(ign.Systemd.Units[1].Name).To(Equal("chronyd.service"))


### PR DESCRIPTION

kind/bug

**What this PR does / why we need it**:
The rke2-install is running a script that is using the command "systemctl". In order for that command to succeed it needs the dbus service up and running. That is how anything communicates with systemd. So there is an actual hard dependency on dbus to be up and running for the rke2-install service to succeed.


**Which issue(s) this PR fixes** 
Fixes # https://jira.suse.com/browse/EDGE-2287

**Special notes for your reviewer**:

**Checklist**:
- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
